### PR TITLE
P1-02: real sendReply HTTP impl with retry/422/auth handling

### DIFF
--- a/src/adapters/outbound/garmin-ipc-inbound.ts
+++ b/src/adapters/outbound/garmin-ipc-inbound.ts
@@ -1,13 +1,194 @@
 import type { Env } from "../../env.js";
+import { log } from "../logging/worker-logs.js";
+
+const MAX_MESSAGE_CHARS = 160;
+const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
 
 /**
- * Send a reply message to an inReach device via Garmin IPC Inbound
- * (POST {base}/api/Messaging/Message; auth via X-API-Key header).
+ * Typed error surfaced from `sendReply`. `code`/`description` come from
+ * Garmin's JSON error body when present (per IPC Inbound v3.1.1 §JSON Error
+ * Object). `code`/`description` may be undefined for transport-layer failures
+ * (network errors, malformed responses).
  *
- * Stub in Phase 0 — real implementation in Phase 1 (P1-XX).
- * Per PRD §4: message body ≤160 chars; paging to a second message for content
- * that exceeds one SMS; retry 1s/4s/16s on 5xx then give up.
+ * `status: 0` is a sentinel for "no HTTP request was made" — used for input
+ * validation failures (empty messages, message too long) and network errors
+ * before any response was received.
  */
-export async function sendReply(_imei: string, _message: string, _env: Env): Promise<void> {
-  throw new Error("sendReply: not implemented in Phase 0 — Phase 1 target");
+export class IpcInboundError extends Error {
+  public readonly status: number;
+  public readonly code?: number;
+  public readonly description?: string;
+
+  constructor(opts: { status: number; message: string; code?: number; description?: string }) {
+    super(opts.message);
+    this.name = "IpcInboundError";
+    this.status = opts.status;
+    this.code = opts.code;
+    this.description = opts.description;
+  }
+}
+
+interface SendReplyOpts {
+  /**
+   * Sleep helper, injectable for tests. Defaults to a real `setTimeout` Promise.
+   */
+  delay?: (ms: number) => Promise<void>;
+}
+
+interface IpcMessageBody {
+  Messages: Array<{
+    Recipients: string[];
+    Sender: string;
+    Timestamp: string;
+    Message: string;
+  }>;
+}
+
+interface IpcErrorBody {
+  Code?: number;
+  Description?: string;
+  Message?: string;
+}
+
+/**
+ * Send a reply to an inReach device via Garmin IPC Inbound.
+ *
+ * Wire format (per `materials/Garmin IPC Inbound.txt` §POST /Message):
+ *   POST {GARMIN_IPC_INBOUND_BASE_URL}/api/Messaging/Message
+ *   Headers: X-API-Key, Content-Type: application/json
+ *   Body: { Messages: [{ Recipients, Sender, Timestamp: "/Date(ms)/", Message }] }
+ *
+ * One HTTP request per message in the input array (Garmin's API supports
+ * batching but per-message requests give simpler delivery IDs and per-message
+ * retry semantics). Each message must be ≤160 chars (Iridium hard cap).
+ *
+ * Retry policy: 5xx, 429, and network errors retry at 1s/4s/16s delays
+ * (initial attempt + up to 3 retries = 4 total per message). 401/403/422
+ * surface immediately as typed `IpcInboundError`.
+ */
+export async function sendReply(
+  imei: string,
+  messages: string[],
+  env: Env,
+  opts: SendReplyOpts = {},
+): Promise<{ count: number }> {
+  if (messages.length === 0) {
+    throw new IpcInboundError({
+      status: 0,
+      message: "sendReply requires at least one message",
+    });
+  }
+  for (const m of messages) {
+    if (m.length > MAX_MESSAGE_CHARS) {
+      throw new IpcInboundError({
+        status: 0,
+        message: `Message length ${m.length} exceeds 160-char Iridium cap (caller bug — page-split before calling sendReply)`,
+      });
+    }
+  }
+
+  const delay = opts.delay ?? defaultDelay;
+  const url = `${env.GARMIN_IPC_INBOUND_BASE_URL}/api/Messaging/Message`;
+
+  let count = 0;
+  for (const message of messages) {
+    await sendOne(url, imei, message, env, delay);
+    count += 1;
+  }
+  return { count };
+}
+
+async function sendOne(
+  url: string,
+  imei: string,
+  message: string,
+  env: Env,
+  delay: (ms: number) => Promise<void>,
+): Promise<void> {
+  const body: IpcMessageBody = {
+    Messages: [
+      {
+        Recipients: [imei],
+        Sender: env.IPC_INBOUND_SENDER,
+        Timestamp: `/Date(${Date.now()})/`,
+        Message: message,
+      },
+    ],
+  };
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      "X-API-Key": env.GARMIN_IPC_INBOUND_API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  };
+
+  let lastErr: IpcInboundError | undefined;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await delay(RETRY_DELAYS_MS[attempt - 1]);
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(url, init);
+    } catch (e) {
+      lastErr = new IpcInboundError({
+        status: 0,
+        message: `network error: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      continue;
+    }
+
+    if (res.ok) return;
+
+    const errBody = await readErrorBody(res);
+    const err = new IpcInboundError({
+      status: res.status,
+      message: errBody.Message ?? `HTTP ${res.status}`,
+      code: errBody.Code,
+      description: errBody.Description,
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      log({
+        event: "auth_fail_outbound",
+        level: "error",
+        status: res.status,
+        code: errBody.Code ?? null,
+      });
+      throw err;
+    }
+    if (res.status === 422) {
+      throw err;
+    }
+
+    lastErr = err;
+  }
+
+  log({
+    event: "reply_delivery_failed",
+    level: "error",
+    imei,
+    status: lastErr?.status ?? null,
+    code: lastErr?.code ?? null,
+    description: lastErr?.description ?? null,
+  });
+  throw (
+    lastErr ??
+    new IpcInboundError({ status: 0, message: "reply delivery failed without a captured error" })
+  );
+}
+
+async function readErrorBody(res: Response): Promise<IpcErrorBody> {
+  try {
+    return (await res.json()) as IpcErrorBody;
+  } catch {
+    return {};
+  }
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/garmin-ipc-inbound.test.ts
+++ b/tests/garmin-ipc-inbound.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { sendReply, IpcInboundError } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+let fetchSpy: MockInstance<typeof fetch>;
+let logSpy: MockInstance<(...args: unknown[]) => void>;
+let errSpy: MockInstance<(...args: unknown[]) => void>;
+
+const noDelay = () => Promise.resolve();
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function loggedEvents(): Array<Record<string, unknown>> {
+  const lines: string[] = [];
+  for (const c of logSpy.mock.calls) lines.push(String(c[0]));
+  for (const c of errSpy.mock.calls) lines.push(String(c[0]));
+  return lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe("sendReply — happy path", () => {
+  test("single message: one HTTP POST to /api/Messaging/Message with X-API-Key + Sender + /Date(ms)/", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    const result = await sendReply("123456789012345", ["pong"], env, { delay: noDelay });
+
+    expect(result).toEqual({ count: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe(`${env.GARMIN_IPC_INBOUND_BASE_URL}/api/Messaging/Message`);
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBe(env.GARMIN_IPC_INBOUND_API_KEY);
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      Messages: Array<{ Recipients: string[]; Sender: string; Timestamp: string; Message: string }>;
+    };
+    expect(body.Messages).toHaveLength(1);
+    const msg = body.Messages[0];
+    expect(msg.Recipients).toEqual(["123456789012345"]);
+    expect(msg.Sender).toBe(env.IPC_INBOUND_SENDER);
+    expect(msg.Message).toBe("pong");
+    expect(msg.Timestamp).toMatch(/^\/Date\(\d+\)\/$/);
+  });
+
+  test("two messages: two sequential HTTP POSTs, count=2", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(200, { count: 1 }))
+      .mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    const result = await sendReply(
+      "123456789012345",
+      ["page one (1/2)", "page two (2/2)"],
+      env,
+      { delay: noDelay },
+    );
+
+    expect(result).toEqual({ count: 2 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const messagesSent = fetchSpy.mock.calls.map((c) => {
+      const body = JSON.parse((c[1] as RequestInit).body as string) as {
+        Messages: Array<{ Message: string }>;
+      };
+      return body.Messages[0].Message;
+    });
+    expect(messagesSent).toEqual(["page one (1/2)", "page two (2/2)"]);
+  });
+});
+
+describe("sendReply — input validation (caller bug)", () => {
+  test("throws synchronously if any message exceeds 160 chars; no fetch issued", async () => {
+    const tooLong = "x".repeat(161);
+    await expect(
+      sendReply("123456789012345", ["ok", tooLong], env, { delay: noDelay }),
+    ).rejects.toThrow(/exceeds 160/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("throws on empty messages array", async () => {
+    await expect(sendReply("123456789012345", [], env, { delay: noDelay })).rejects.toThrow(
+      /at least one message/,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendReply — Garmin error responses", () => {
+  test("422 surfaces {Code, Description} in the typed error", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(422, {
+        Code: 5,
+        Description: "Message length 200 exceeds maximum of 160.",
+        Message: "InvalidMessageError",
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await sendReply("123456789012345", ["whatever"], env, { delay: noDelay });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(IpcInboundError);
+    const err = caught as IpcInboundError;
+    expect(err.status).toBe(422);
+    expect(err.code).toBe(5);
+    expect(err.message).toMatch(/InvalidMessageError/);
+    expect(err.description).toMatch(/exceeds maximum/);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("401 logs auth_fail_outbound and rethrows", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(401, { Code: 1, Description: "Unauthorized" }),
+    );
+
+    await expect(
+      sendReply("123456789012345", ["pong"], env, { delay: noDelay }),
+    ).rejects.toBeInstanceOf(IpcInboundError);
+
+    const events = loggedEvents().map((e) => e.event);
+    expect(events).toContain("auth_fail_outbound");
+  });
+
+  test("403 also logs auth_fail_outbound and rethrows", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(403, { Code: 1 }));
+
+    await expect(
+      sendReply("123456789012345", ["pong"], env, { delay: noDelay }),
+    ).rejects.toBeInstanceOf(IpcInboundError);
+
+    const events = loggedEvents().map((e) => e.event);
+    expect(events).toContain("auth_fail_outbound");
+  });
+});
+
+describe("sendReply — retry semantics (5xx/429)", () => {
+  test("5xx → success on second attempt; total 2 fetch calls; result count=1", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(500, { Code: 1, Description: "InternalError" }))
+      .mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    const result = await sendReply("123456789012345", ["pong"], env, { delay: noDelay });
+    expect(result).toEqual({ count: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("429 with Retry-After is also retried", async () => {
+    const tooMany = new Response(JSON.stringify({ Code: 2 }), {
+      status: 429,
+      headers: { "content-type": "application/json", "retry-after": "1" },
+    });
+    fetchSpy
+      .mockResolvedValueOnce(tooMany)
+      .mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    const result = await sendReply("123456789012345", ["pong"], env, { delay: noDelay });
+    expect(result).toEqual({ count: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("all retries exhausted (initial + 3 retries) → log reply_delivery_failed, rethrow", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(500, { Code: 1 }))
+      .mockResolvedValueOnce(jsonResponse(502, { Code: 1 }))
+      .mockResolvedValueOnce(jsonResponse(503, { Code: 1 }))
+      .mockResolvedValueOnce(jsonResponse(504, { Code: 1 }));
+
+    await expect(
+      sendReply("123456789012345", ["pong"], env, { delay: noDelay }),
+    ).rejects.toBeInstanceOf(IpcInboundError);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    const events = loggedEvents().map((e) => e.event);
+    expect(events).toContain("reply_delivery_failed");
+  });
+
+  test("network error (fetch rejects) is also retried", async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError("network down"))
+      .mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    const result = await sendReply("123456789012345", ["pong"], env, { delay: noDelay });
+    expect(result).toEqual({ count: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("retry delays follow 1s/4s/16s schedule before retries 1, 2, 3", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(500, { Code: 1 }))
+      .mockResolvedValueOnce(jsonResponse(500, { Code: 1 }))
+      .mockResolvedValueOnce(jsonResponse(500, { Code: 1 }))
+      .mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    const sleptMs: number[] = [];
+    const recordingDelay = (ms: number): Promise<void> => {
+      sleptMs.push(ms);
+      return Promise.resolve();
+    };
+
+    await sendReply("123456789012345", ["pong"], env, { delay: recordingDelay });
+    expect(sleptMs).toEqual([1000, 4000, 16000]);
+  });
+});


### PR DESCRIPTION
## Summary

Real implementation of `sendReply` against Garmin IPC Inbound v3.1.1. POST `{GARMIN_IPC_INBOUND_BASE_URL}/api/Messaging/Message` with `X-API-Key`. One HTTP request per message in the input array.

Closes #38.

### Wire format (per `materials/Garmin IPC Inbound.txt` §POST /Message)

```json
{ "Messages": [{
  "Recipients": ["<imei>"],
  "Sender": "<env.IPC_INBOUND_SENDER>",
  "Timestamp": "/Date(<ms>)/",
  "Message": "<≤160 chars>"
}]}
```

The `/Date(ms)/` wrapper is .NET's WCF JSON date encoding — Garmin's API was built on .NET, and this is one of the few places that history shows in the wire format.

### API surface

- `sendReply(imei, messages: string[], env, opts?): Promise<{ count }>`
- `IpcInboundError` — typed error carrying `status`, `code`, `description`. `status: 0` is a sentinel for "no HTTP request was made" (input validation, network errors).
- `opts.delay` — injectable sleep helper for tests; defaults to `setTimeout`.

### Retry policy

- **5xx, 429, network errors:** retry at 1s/4s/16s (initial + up to 3 retries = **4 attempts max** per message). After exhaustion: log `reply_delivery_failed` and rethrow.
- **401/403:** log `auth_fail_outbound` and surface immediately (not transient — API key is wrong, alerting required).
- **422:** surface `{Code, Description}` from Garmin's JSON error body immediately (e.g. `InvalidMessageError` code 5 if a message slipped past our client-side length check).

### Validation (caller-bug failures, no HTTP issued)

- Empty `messages` array → `IpcInboundError("at least one message")`
- Any message > 160 chars → `IpcInboundError("exceeds 160-char Iridium cap")`. P1-15 owns page-splitting; this is a hard contract assertion.

## ⚠️ Stacked on PR #61

This PR is **stacked on `p1-03-04-llm-env-rename`** (PR #61) because the new env var `IPC_INBOUND_SENDER` is added there. Merge order: **#61 → this PR**. After #61 merges, GitHub will auto-update this PR's base to `main`.

## ⚠️ PR #60 (P1-01) needs a one-char rebase

PR #60's `src/app.ts` calls `sendReply(event.imei, body, env)` with a single string. This PR changes the signature to `(imei, messages: string[], env, opts?)` per the plan. After both PRs land, #60's rebase needs:

```diff
- await sendReply(event.imei, body, env);
+ await sendReply(event.imei, [body], env);
```

(Plan signature wins; pre-empting with `string | string[]` here would just accrete compatibility for a caller that doesn't yet exist on main.)

## Test plan

- [x] 12 Vitest cases — all green:
  - happy single message + happy two-message (one HTTP per message)
  - empty input (sync throw, no fetch)
  - oversized message (sync throw, no fetch)
  - 422 surfaces Code+Description in `IpcInboundError`
  - 401 + 403 log `auth_fail_outbound` and rethrow
  - 5xx → success on retry (2 fetches total)
  - 429 + Retry-After also retried
  - Network error (fetch rejects) is retried
  - Full retry exhaustion: 4 fetch calls, `reply_delivery_failed` logged
  - Retry delays match `[1000, 4000, 16000]` schedule
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 36/36 (12 new + 24 existing on PR #61's base)
- [ ] CI green
- [ ] Post-merge: P1-19 (`!ping`/`!help`/`!cost` real reply paths) and P1-16/17/18 (command pipelines) become unblocked.