### PR TITLE
P1-06: Resend mail adapter (real send) [closes #42]

### DIFF
--- a/src/adapters/mail/resend.ts
+++ b/src/adapters/mail/resend.ts
@@ -1,16 +1,111 @@
 import type { Env } from "../../env.js";
 
+const RESEND_URL = "https://api.resend.com/emails";
+const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
+
 export interface SendEmailArgs {
   to: string;
   subject: string;
   body: string;
   env: Env;
+  /** Injectable sleep helper for tests; defaults to setTimeout. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Typed error from Resend. `errorName`/`message` come from Resend's JSON
+ * error body when present (e.g. `{ name: "validation_error", message: "..." }`).
+ */
+export class ResendError extends Error {
+  public readonly status: number;
+  public readonly errorName?: string;
+
+  constructor(opts: { status: number; message: string; errorName?: string }) {
+    super(opts.message);
+    this.name = "ResendError";
+    this.status = opts.status;
+    this.errorName = opts.errorName;
+  }
+}
+
+interface ResendErrorBody {
+  name?: string;
+  message?: string;
 }
 
 /**
  * Send a transactional email via Resend.
- * Stub in Phase 0 — real implementation in Phase 1.
+ *
+ * α-MVP: plain-text only (`text` field), no HTML rendering. From-line built
+ * from `RESEND_FROM_NAME` + `RESEND_FROM_EMAIL` ("TrailScribe <…>"). 4xx
+ * errors surface immediately with the parsed Resend error body. 5xx and
+ * network errors retry at 1s/4s/16s (initial + 3 retries = 4 attempts).
+ *
+ * The free `trailscribe@resend.dev` sender doesn't require DNS — Resend owns
+ * that domain. Custom-domain sender is Production-readiness #25.
  */
-export async function sendEmail(_args: SendEmailArgs): Promise<void> {
-  throw new Error("sendEmail: not implemented in Phase 0 — Phase 1 target");
+export async function sendEmail(args: SendEmailArgs): Promise<{ id: string }> {
+  const { to, subject, body, env } = args;
+  const delay = args.delay ?? defaultDelay;
+  const from = `${env.RESEND_FROM_NAME} <${env.RESEND_FROM_EMAIL}>`;
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ from, to, subject, text: body }),
+  };
+
+  let lastErr: ResendError | undefined;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await delay(RETRY_DELAYS_MS[attempt - 1]);
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(RESEND_URL, init);
+    } catch (e) {
+      lastErr = new ResendError({
+        status: 0,
+        message: `network error: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      continue;
+    }
+
+    if (res.ok) {
+      const data = (await res.json()) as { id: string };
+      return { id: data.id };
+    }
+
+    const errBody = await readErrorBody(res);
+    const err = new ResendError({
+      status: res.status,
+      message: errBody.message ?? `HTTP ${res.status}`,
+      errorName: errBody.name,
+    });
+
+    if (res.status >= 400 && res.status < 500) {
+      throw err;
+    }
+    lastErr = err;
+  }
+
+  throw (
+    lastErr ??
+    new ResendError({ status: 0, message: "send failed without a captured error" })
+  );
+}
+
+async function readErrorBody(res: Response): Promise<ResendErrorBody> {
+  try {
+    return (await res.json()) as ResendErrorBody;
+  } catch {
+    return {};
+  }
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/resend.test.ts
+++ b/tests/resend.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { sendEmail, ResendError } from "../src/adapters/mail/resend.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+let fetchSpy: MockInstance<typeof fetch>;
+
+const noDelay = () => Promise.resolve();
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("sendEmail — happy path", () => {
+  test("POSTs to https://api.resend.com/emails with Bearer auth, formatted From, plain text body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(200, { id: "msg_abc123" }));
+
+    const result = await sendEmail({
+      to: "alice@example.com",
+      subject: "field check",
+      body: "all good\nstill on schedule",
+      env,
+      delay: noDelay,
+    });
+
+    expect(result).toEqual({ id: "msg_abc123" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe("https://api.resend.com/emails");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Bearer ${env.RESEND_API_KEY}`);
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.from).toBe(`${env.RESEND_FROM_NAME} <${env.RESEND_FROM_EMAIL}>`);
+    expect(body.to).toBe("alice@example.com");
+    expect(body.subject).toBe("field check");
+    expect(body.text).toBe("all good\nstill on schedule");
+    expect(body.html).toBeUndefined();
+  });
+});
+
+describe("sendEmail — error paths", () => {
+  test("400 invalid recipient surfaces typed ResendError with name + message", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(400, {
+        name: "validation_error",
+        message: "Invalid `to` field: not an email",
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await sendEmail({
+        to: "not-an-email",
+        subject: "x",
+        body: "y",
+        env,
+        delay: noDelay,
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(ResendError);
+    const err = caught as ResendError;
+    expect(err.status).toBe(400);
+    expect(err.errorName).toBe("validation_error");
+    expect(err.message).toMatch(/Invalid `to`/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("422 invalid recipient is also surfaced (not retried)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(422, { name: "missing_required_field", message: "subject required" }),
+    );
+    await expect(
+      sendEmail({ to: "a@b.com", subject: "", body: "y", env, delay: noDelay }),
+    ).rejects.toBeInstanceOf(ResendError);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("5xx retried with 1s/4s/16s schedule; success on third attempt", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(500, { message: "boom" }))
+      .mockResolvedValueOnce(jsonResponse(502, { message: "bad gateway" }))
+      .mockResolvedValueOnce(jsonResponse(200, { id: "msg_xyz" }));
+
+    const sleeps: number[] = [];
+    const recordingDelay = (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+
+    const result = await sendEmail({
+      to: "a@b.com",
+      subject: "x",
+      body: "y",
+      env,
+      delay: recordingDelay,
+    });
+    expect(result).toEqual({ id: "msg_xyz" });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([1000, 4000]);
+  });
+
+  test("network error retried", async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(jsonResponse(200, { id: "msg_x" }));
+
+    const result = await sendEmail({
+      to: "a@b.com",
+      subject: "x",
+      body: "y",
+      env,
+      delay: noDelay,
+    });
+    expect(result.id).toBe("msg_x");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("all retries exhausted → throws ResendError", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(500, { message: "boom" }))
+      .mockResolvedValueOnce(jsonResponse(503, { message: "down" }))
+      .mockResolvedValueOnce(jsonResponse(504, { message: "timeout" }))
+      .mockResolvedValueOnce(jsonResponse(502, { message: "still down" }));
+
+    await expect(
+      sendEmail({ to: "a@b.com", subject: "x", body: "y", env, delay: noDelay }),
+    ).rejects.toBeInstanceOf(ResendError);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Summary

`sendEmail({to, subject, body, env}): Promise<{id}>` — POSTs to `https://api.resend.com/emails` with Bearer auth. Plain-text only for α (`text` field; no `html`). Returns the Resend message id.

Closes #42.

### Wire format
```http
POST /emails HTTP/1.1
Host: api.resend.com
Authorization: Bearer <RESEND_API_KEY>
Content-Type: application/json

{ "from": "TrailScribe <trailscribe@resend.dev>", "to": "...", "subject": "...", "text": "..." }
```

### Errors
- **4xx** (validation/invalid recipient/missing field): surface immediately as `ResendError` carrying `status` + `errorName` + `message` from Resend's JSON error body. Not retried.
- **5xx + network**: retry at `1s/4s/16s` (initial + 3 retries = 4 attempts per call). After exhaustion, throw `ResendError`.

### Notes

The free-tier `trailscribe@resend.dev` sender doesn't require DNS — Resend owns that domain. Custom-domain sender is Production-readiness #25 (separate gate).

Branched off `main` (no shared deps with the ledger/env-rename stack).

## Unblocks

**P1-17** (`!mail` pipeline) — composes the body with location/weather and calls this.

## Test plan

- [x] 6 Vitest cases (mocked fetch):
  - Success: URL + Bearer auth + From-line format + plain-text body
  - 400 invalid recipient → `ResendError` with `name` + `message`
  - 422 missing field → `ResendError`, not retried
  - 5xx → success on third attempt; sleep schedule = `[1000, 4000]`
  - Network error retried
  - Full retry exhaustion (4 fetch calls) → throws
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 30/30
- [ ] CI green