### PR TITLE
P1-07: Todoist tasks adapter (real create) [closes #43]

### DIFF
--- a/src/adapters/tasks/todoist.ts
+++ b/src/adapters/tasks/todoist.ts
@@ -1,15 +1,111 @@
 import type { Env } from "../../env.js";
 
+const TODOIST_URL = "https://api.todoist.com/rest/v2/tasks";
+const TODOIST_TASK_URL = "https://todoist.com/showTask?id=";
+const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
+
 export interface AddTaskArgs {
   task: string;
-  note?: string;
+  lat?: number;
+  lon?: number;
+  /** Wall-clock ms (Garmin event timeStamp). */
+  timestamp: number;
   env: Env;
+  /** Injectable sleep helper for tests; defaults to setTimeout. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+export class TodoistError extends Error {
+  public readonly status: number;
+  public readonly body?: unknown;
+
+  constructor(opts: { status: number; message: string; body?: unknown }) {
+    super(opts.message);
+    this.name = "TodoistError";
+    this.status = opts.status;
+    this.body = opts.body;
+  }
 }
 
 /**
- * Create a task in Todoist via REST API.
- * Stub in Phase 0 — real implementation in Phase 1.
+ * Create a Todoist task. With lat/lon present, the description carries the
+ * coords + ISO timestamp ("From inReach: 37.1682,-118.5891 @ 2025-02-17T14:20:15.000Z");
+ * without GPS, just the timestamp. No `due_string` for α — Phase 2+ may
+ * parse `!todo <task> by:tomorrow`.
+ *
+ * Returns the task id and the public Todoist URL for inclusion in the reply.
+ *
+ * 4xx errors surface immediately; 5xx + network retry at 1s/4s/16s.
  */
-export async function addTask(_args: AddTaskArgs): Promise<void> {
-  throw new Error("addTask: not implemented in Phase 0 — Phase 1 target");
+export async function addTask(args: AddTaskArgs): Promise<{ id: string; url: string }> {
+  const { task, lat, lon, timestamp, env } = args;
+  const delay = args.delay ?? defaultDelay;
+  const description = formatDescription(timestamp, lat, lon);
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.TODOIST_API_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ content: task, description }),
+  };
+
+  let lastErr: TodoistError | undefined;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await delay(RETRY_DELAYS_MS[attempt - 1]);
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(TODOIST_URL, init);
+    } catch (e) {
+      lastErr = new TodoistError({
+        status: 0,
+        message: `network error: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      continue;
+    }
+
+    if (res.ok) {
+      const data = (await res.json()) as { id: string };
+      return { id: data.id, url: `${TODOIST_TASK_URL}${data.id}` };
+    }
+
+    const body = await readErrorBody(res);
+    const err = new TodoistError({
+      status: res.status,
+      message: `Todoist HTTP ${res.status}`,
+      body,
+    });
+
+    if (res.status >= 400 && res.status < 500) {
+      throw err;
+    }
+    lastErr = err;
+  }
+
+  throw (
+    lastErr ?? new TodoistError({ status: 0, message: "addTask failed without a captured error" })
+  );
+}
+
+function formatDescription(timestamp: number, lat?: number, lon?: number): string {
+  const iso = new Date(timestamp).toISOString();
+  if (lat !== undefined && lon !== undefined) {
+    return `From inReach: ${lat},${lon} @ ${iso}`;
+  }
+  return `From inReach — sent ${iso}`;
+}
+
+async function readErrorBody(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/todoist.test.ts
+++ b/tests/todoist.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { addTask, TodoistError } from "../src/adapters/tasks/todoist.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+let fetchSpy: MockInstance<typeof fetch>;
+
+const noDelay = () => Promise.resolve();
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("addTask — happy path", () => {
+  test("with lat/lon: description includes coords + ISO timestamp; returns id + URL", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, { id: "t_8675309", content: "buy waterfilter cartridge" }),
+    );
+
+    const result = await addTask({
+      task: "buy waterfilter cartridge",
+      lat: 37.1682,
+      lon: -118.5891,
+      timestamp: 1739802015000,
+      env,
+      delay: noDelay,
+    });
+
+    expect(result).toEqual({
+      id: "t_8675309",
+      url: "https://todoist.com/showTask?id=t_8675309",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe("https://api.todoist.com/rest/v2/tasks");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Bearer ${env.TODOIST_API_TOKEN}`);
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.content).toBe("buy waterfilter cartridge");
+    expect(body.description).toContain("From inReach");
+    expect(body.description).toContain("37.1682,-118.5891");
+    expect(body.description).toContain("2025-02-17");
+    expect(body.due_string).toBeUndefined();
+  });
+
+  test("without lat/lon: description omits coords; only timestamp shown", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(200, { id: "t_x" }));
+
+    await addTask({
+      task: "follow up",
+      timestamp: 1739802015000,
+      env,
+      delay: noDelay,
+    });
+
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.description).toBe("From inReach — sent 2025-02-17T14:20:15.000Z");
+    expect(body.description).not.toContain(",");
+  });
+});
+
+describe("addTask — error paths", () => {
+  test("401 bad token surfaces TodoistError", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(401, { error: "AUTH_INVALID_TOKEN" }),
+    );
+
+    let caught: unknown;
+    try {
+      await addTask({
+        task: "x",
+        timestamp: 0,
+        env,
+        delay: noDelay,
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TodoistError);
+    expect((caught as TodoistError).status).toBe(401);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("403 forbidden also surfaced (not retried)", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(403, { error: "Forbidden" }));
+    await expect(
+      addTask({ task: "x", timestamp: 0, env, delay: noDelay }),
+    ).rejects.toBeInstanceOf(TodoistError);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("5xx retried at 1s/4s/16s, success on third attempt", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(500, { error: "boom" }))
+      .mockResolvedValueOnce(jsonResponse(503, { error: "down" }))
+      .mockResolvedValueOnce(jsonResponse(200, { id: "t_99" }));
+
+    const sleeps: number[] = [];
+    const recordingDelay = (ms: number): Promise<void> => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+
+    const result = await addTask({
+      task: "x",
+      timestamp: 0,
+      env,
+      delay: recordingDelay,
+    });
+    expect(result.id).toBe("t_99");
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([1000, 4000]);
+  });
+
+  test("network error retried", async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError("network"))
+      .mockResolvedValueOnce(jsonResponse(200, { id: "t_1" }));
+    const r = await addTask({ task: "x", timestamp: 0, env, delay: noDelay });
+    expect(r.id).toBe("t_1");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

`addTask({task, lat?, lon?, timestamp, env}): Promise<{id, url}>` — POSTs to `https://api.todoist.com/rest/v2/tasks` with Bearer auth. Returns the task id plus public URL for inclusion in the device reply.

Closes #43.

### Description format
- With lat/lon: `"From inReach: <lat>,<lon> @ <ISO>"`
- Without GPS: `"From inReach — sent <ISO>"`

No `due_string` for α — undated tasks. Phase 2+ may parse `!todo by:tomorrow`.

### Errors (matches P1-06 / P1-02 retry shape)
- **4xx**: typed `TodoistError` carrying `status` + raw body. Not retried.
- **5xx + network**: retry at `1s/4s/16s` (initial + 3 retries = 4 max). After exhaustion, throw.

Branched off `main` (no shared deps).

## Unblocks

**P1-18** (`!todo` pipeline) — calls this and includes the returned URL in the device reply.

## Test plan

- [x] 6 Vitest cases (mocked fetch):
  - Success with lat/lon: URL + Bearer auth + content/description shape + returned task URL
  - Success without GPS: description omits coords
  - 401 bad token → `TodoistError`, not retried
  - 403 also surfaced
  - 5xx → success on third attempt; sleep schedule `[1000, 4000]`
  - Network error retried
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 30/30
- [ ] CI green