### PR TITLE
P1-09: Nominatim reverse-geocode adapter (KV-cached) [closes #45]

### DIFF
--- a/src/adapters/location/geocode.ts
+++ b/src/adapters/location/geocode.ts
@@ -1,10 +1,81 @@
 import type { Env } from "../../env.js";
+import { log } from "../logging/worker-logs.js";
+
+const NOMINATIM_BASE = "https://nominatim.openstreetmap.org/reverse";
+const USER_AGENT = "trailscribe (https://github.com/brockamer/trailscribe)";
+const CACHE_TTL_SECONDS = 86400;
+const MAX_NAME_LENGTH = 60;
+const FALLBACK = "unknown location";
+
+interface NominatimAddress {
+  peak?: string;
+  locality?: string;
+  town?: string;
+  village?: string;
+  city?: string;
+  county?: string;
+  state?: string;
+}
+
+interface NominatimResponse {
+  display_name?: string;
+  address?: NominatimAddress;
+}
 
 /**
- * Reverse-geocode (lat, lon) to a human-readable place string via Nominatim,
- * cached in `env.TS_CACHE` under `geo:<lat:4,lon:4>` with 24h TTL.
- * Stub in Phase 0 — real implementation in Phase 1.
+ * Reverse-geocode `(lat, lon)` to a short human-readable place name suitable
+ * for embedding in a 320-char SMS reply. KV-cached at the rounded
+ * 4-decimal-degree (~11m) grid for 24 hours so repeat positions don't re-hit
+ * Nominatim, which has a 1-req/sec polite-use policy.
+ *
+ * Caller responsibility: never invoke when lat/lon are absent or both zero
+ * (orchestrator strips them in P1-01).
+ *
+ * Errors are non-fatal — Nominatim downtime returns `"unknown location"`
+ * instead of throwing, since geocoding is enrichment, not core functionality.
  */
-export async function reverseGeocode(_lat: number, _lon: number, _env: Env): Promise<string> {
-  throw new Error("reverseGeocode: not implemented in Phase 0 — Phase 1 target");
+export async function reverseGeocode(lat: number, lon: number, env: Env): Promise<string> {
+  const key = `geo:${lat.toFixed(4)}:${lon.toFixed(4)}`;
+  const cached = await env.TS_CACHE.get(key);
+  if (cached !== null) return cached;
+
+  const url = `${NOMINATIM_BASE}?format=jsonv2&lat=${lat}&lon=${lon}`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+  } catch (e) {
+    log({
+      event: "geocode_failed",
+      level: "warn",
+      reason: "network",
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return FALLBACK;
+  }
+
+  if (!res.ok) {
+    log({ event: "geocode_failed", level: "warn", reason: "http", status: res.status });
+    return FALLBACK;
+  }
+
+  let data: NominatimResponse;
+  try {
+    data = (await res.json()) as NominatimResponse;
+  } catch {
+    log({ event: "geocode_failed", level: "warn", reason: "bad_json" });
+    return FALLBACK;
+  }
+
+  const name = shortenName(data);
+  await env.TS_CACHE.put(key, name, { expirationTtl: CACHE_TTL_SECONDS });
+  return name;
+}
+
+function shortenName(data: NominatimResponse): string {
+  const a = data.address ?? {};
+  const place = a.peak ?? a.locality ?? a.town ?? a.village ?? a.city ?? a.county;
+  const parts = [place, a.state].filter((p): p is string => Boolean(p));
+  if (parts.length === 0) return FALLBACK;
+  const joined = parts.join(", ");
+  return joined.length > MAX_NAME_LENGTH ? joined.slice(0, MAX_NAME_LENGTH) : joined;
 }

--- a/tests/geocode.test.ts
+++ b/tests/geocode.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { reverseGeocode } from "../src/adapters/location/geocode.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+let fetchSpy: MockInstance<typeof fetch>;
+let logSpy: MockInstance<(...args: unknown[]) => void>;
+let errSpy: MockInstance<(...args: unknown[]) => void>;
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function loggedEvents(): Array<Record<string, unknown>> {
+  const lines: string[] = [];
+  for (const c of logSpy.mock.calls) lines.push(String(c[0]));
+  for (const c of errSpy.mock.calls) lines.push(String(c[0]));
+  return lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe("reverseGeocode — cache", () => {
+  test("cache hit: returns stored value, no fetch issued", async () => {
+    await env.TS_CACHE.put("geo:37.1682:-118.5891", "Palisade Glacier, CA");
+
+    const result = await reverseGeocode(37.1682, -118.5891, env);
+    expect(result).toBe("Palisade Glacier, CA");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("cache miss: fetches Nominatim, caches result with 24h TTL, returns short name", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, {
+        display_name: "Palisade Glacier, Inyo County, California, United States",
+        address: {
+          peak: "Palisade Glacier",
+          county: "Inyo County",
+          state: "California",
+        },
+      }),
+    );
+    const putSpy = vi.spyOn(env.TS_CACHE, "put");
+
+    const result = await reverseGeocode(37.1682, -118.5891, env);
+    expect(result).toContain("Palisade Glacier");
+    expect(result).toContain("California");
+    expect(result.length).toBeLessThanOrEqual(60);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toMatch(
+      /^https:\/\/nominatim\.openstreetmap\.org\/reverse\?format=jsonv2&lat=37\.1682&lon=-118\.5891$/,
+    );
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["User-Agent"]).toMatch(/trailscribe/i);
+
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    const [cacheKey, , opts] = putSpy.mock.calls[0];
+    expect(String(cacheKey)).toBe("geo:37.1682:-118.5891");
+    expect((opts as { expirationTtl?: number } | undefined)?.expirationTtl).toBe(86400);
+  });
+
+  test("cache key rounds lat/lon to 4 decimals (~11m grid) so nearby positions share cache", async () => {
+    await env.TS_CACHE.put("geo:37.1682:-118.5891", "Palisade Glacier, CA");
+
+    // Same 4-decimal cell, sub-meter offset
+    const result = await reverseGeocode(37.16819, -118.58912, env);
+    expect(result).toBe("Palisade Glacier, CA");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("reverseGeocode — short-name strategy", () => {
+  test("prefers locality > town > village > county when no peak", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, {
+        display_name: "very long full name",
+        address: { town: "Bishop", state: "California", county: "Inyo County" },
+      }),
+    );
+    const result = await reverseGeocode(37.36, -118.4, env);
+    expect(result).toContain("Bishop");
+    expect(result).toContain("California");
+  });
+});
+
+describe("reverseGeocode — error fallback", () => {
+  test("Nominatim 5xx → return 'unknown location' (does not throw)", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(503, { error: "down" }));
+    const result = await reverseGeocode(37.1682, -118.5891, env);
+    expect(result).toBe("unknown location");
+
+    const events = loggedEvents().map((e) => e.event);
+    expect(events).toContain("geocode_failed");
+  });
+
+  test("network error → return 'unknown location'", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("network"));
+    const result = await reverseGeocode(37.1682, -118.5891, env);
+    expect(result).toBe("unknown location");
+  });
+
+  test("404 (no address found) → return 'unknown location'", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(404, { error: "not found" }));
+    const result = await reverseGeocode(0.0001, 0.0001, env);
+    expect(result).toBe("unknown location");
+  });
+});


### PR DESCRIPTION
## Summary

`reverseGeocode(lat, lon, env): Promise<string>` — short place name for SMS replies. KV-cached at the 4-decimal-degree (~11m) grid for 24 hours.

Closes #45.

### Why caching matters

Nominatim is OpenStreetMap's free reverse-geocode service. Their terms require:
- ≤ 1 req/sec (enforced by terms-of-use; abuse gets you banned)
- An identifying `User-Agent` (`trailscribe (https://github.com/brockamer/trailscribe)`)

Our cache key rounds to 4 decimal degrees, which is roughly an 11-meter grid cell. Two consecutive reads from the same patch of trail (Garmin's GPS is ~5m precise) hit the same cache key, so repeat positions never re-fetch. Effectively trivial-compliant with Nominatim's policy.

### Short-name strategy

`address.peak || locality || town || village || city || county`, then `state`, joined `", "`, truncated to 60 chars. Falls back to `"unknown location"` if neither place nor county is present.

### Errors non-fatal

Network / 4xx / 5xx / bad JSON → log `geocode_failed` with reason, return `"unknown location"`. Geocoding is enrichment; an outage shouldn't break `!post`. Caller responsibility (per plan): never invoke when lat/lon undefined or both zero — P1-01 orchestrator strips them; adapter doesn't defend.

Branched off `main` (cache stores plain strings, no JSON-mock dep).

## Unblocks

**P1-16** (`!post` enrichment) and **P1-17** (`!mail` enrichment).

## Test plan

- [x] 7 Vitest cases:
  - Cache hit returns stored value, no fetch
  - Cache miss fetches, caches with 24h TTL, returns short name
  - Cache key rounds to 4 decimals (sub-meter offset → same cell)
  - Short-name strategy: town + state composition
  - 5xx → `"unknown location"` + `geocode_failed` log
  - Network error → fallback
  - 404 → fallback
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 31/31
- [ ] CI green