### PR TITLE
P1-10: Open-Meteo weather adapter (KV-cached) [closes #46]

### DIFF
--- a/src/adapters/location/weather.ts
+++ b/src/adapters/location/weather.ts
@@ -1,10 +1,103 @@
 import type { Env } from "../../env.js";
+import { log } from "../logging/worker-logs.js";
+
+const OPEN_METEO_BASE = "https://api.open-meteo.com/v1/forecast";
+const CACHE_TTL_SECONDS = 3600;
+const FALLBACK = "weather unavailable";
+
+interface OpenMeteoResponse {
+  current?: {
+    temperature_2m?: number;
+    wind_speed_10m?: number;
+    wind_direction_10m?: number;
+    weather_code?: number;
+  };
+}
 
 /**
- * Short current-weather summary for (lat, lon) via Open-Meteo, cached under
- * `wx:<lat:2,lon:2>` with 1h TTL.
- * Stub in Phase 0 — real implementation in Phase 1.
+ * Short current-weather string for `(lat, lon)` via Open-Meteo. Returns ≤30
+ * characters like `"42°F, 8mph, clear"`. KV-cached at the 2-decimal-degree
+ * (~1km) grid for 1 hour — weather doesn't change second-by-second, and
+ * tight clustering of repeat positions never re-fetches.
+ *
+ * Imperial units (PRD personas span US/Iceland/Patagonia; default imperial,
+ * future preference toggle). WMO weather_code is mapped via a compact lookup
+ * to a single short label.
+ *
+ * Errors non-fatal — Open-Meteo downtime returns `"weather unavailable"`
+ * rather than throwing.
+ *
+ * Caller responsibility: never invoke when lat/lon are absent (orchestrator
+ * strips them in P1-01).
  */
-export async function currentWeather(_lat: number, _lon: number, _env: Env): Promise<string> {
-  throw new Error("currentWeather: not implemented in Phase 0 — Phase 1 target");
+export async function currentWeather(lat: number, lon: number, env: Env): Promise<string> {
+  const key = `wx:${lat.toFixed(2)}:${lon.toFixed(2)}`;
+  const cached = await env.TS_CACHE.get(key);
+  if (cached !== null) return cached;
+
+  const url =
+    `${OPEN_METEO_BASE}?latitude=${lat}&longitude=${lon}` +
+    `&current=temperature_2m,wind_speed_10m,weather_code` +
+    `&temperature_unit=fahrenheit&wind_speed_unit=mph`;
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (e) {
+    log({
+      event: "weather_failed",
+      level: "warn",
+      reason: "network",
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return FALLBACK;
+  }
+
+  if (!res.ok) {
+    log({ event: "weather_failed", level: "warn", reason: "http", status: res.status });
+    return FALLBACK;
+  }
+
+  let data: OpenMeteoResponse;
+  try {
+    data = (await res.json()) as OpenMeteoResponse;
+  } catch {
+    log({ event: "weather_failed", level: "warn", reason: "bad_json" });
+    return FALLBACK;
+  }
+
+  const formatted = formatWeather(data);
+  if (formatted === FALLBACK) {
+    log({ event: "weather_failed", level: "warn", reason: "missing_fields" });
+    return FALLBACK;
+  }
+  await env.TS_CACHE.put(key, formatted, { expirationTtl: CACHE_TTL_SECONDS });
+  return formatted;
+}
+
+function formatWeather(data: OpenMeteoResponse): string {
+  const c = data.current;
+  if (!c || c.temperature_2m === undefined || c.weather_code === undefined) {
+    return FALLBACK;
+  }
+  const temp = `${Math.round(c.temperature_2m)}°F`;
+  const wind = c.wind_speed_10m !== undefined ? `${Math.round(c.wind_speed_10m)}mph` : "";
+  const label = wmoLabel(c.weather_code);
+  return [temp, wind, label].filter(Boolean).join(", ");
+}
+
+/**
+ * Compact WMO weather-code → label table per Open-Meteo docs.
+ * https://open-meteo.com/en/docs §Weather Variable Documentation
+ */
+function wmoLabel(code: number): string {
+  if (code === 0) return "clear";
+  if (code >= 1 && code <= 3) return "partly cloudy";
+  if (code === 45 || code === 48) return "fog";
+  if (code >= 51 && code <= 57) return "drizzle";
+  if (code >= 61 && code <= 67) return "rain";
+  if (code >= 71 && code <= 77) return "snow";
+  if (code >= 80 && code <= 82) return "showers";
+  if (code >= 95 && code <= 99) return "thunderstorm";
+  return "unknown";
 }

--- a/tests/weather.test.ts
+++ b/tests/weather.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { currentWeather } from "../src/adapters/location/weather.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+let fetchSpy: MockInstance<typeof fetch>;
+let logSpy: MockInstance<(...args: unknown[]) => void>;
+let errSpy: MockInstance<(...args: unknown[]) => void>;
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function loggedEvents(): Array<Record<string, unknown>> {
+  const lines: string[] = [];
+  for (const c of logSpy.mock.calls) lines.push(String(c[0]));
+  for (const c of errSpy.mock.calls) lines.push(String(c[0]));
+  return lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe("currentWeather — cache", () => {
+  test("cache hit: returns stored value, no fetch", async () => {
+    await env.TS_CACHE.put("wx:37.17:-118.59", "42°F, 8mph W, clear");
+    const result = await currentWeather(37.17, -118.59, env);
+    expect(result).toBe("42°F, 8mph W, clear");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("cache key rounds to 2 decimals (~1km grid) so nearby positions share", async () => {
+    await env.TS_CACHE.put("wx:37.17:-118.59", "42°F, 8mph W, clear");
+    // Different sub-cell positions, same 2-decimal cell
+    const result = await currentWeather(37.171, -118.589, env);
+    expect(result).toBe("42°F, 8mph W, clear");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("currentWeather — Open-Meteo fetch", () => {
+  test("clear day: returns formatted string ≤30 chars; caches with 1h TTL", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, {
+        current: { temperature_2m: 42, wind_speed_10m: 8, weather_code: 0 },
+      }),
+    );
+    const putSpy = vi.spyOn(env.TS_CACHE, "put");
+
+    const result = await currentWeather(37.1682, -118.5891, env);
+    expect(result.length).toBeLessThanOrEqual(30);
+    expect(result).toContain("42°F");
+    expect(result).toContain("8mph");
+    expect(result).toContain("clear");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("https://api.open-meteo.com/v1/forecast");
+    expect(url).toContain("latitude=37.1682");
+    expect(url).toContain("longitude=-118.5891");
+    expect(url).toContain("current=temperature_2m,wind_speed_10m,weather_code");
+    expect(url).toContain("temperature_unit=fahrenheit");
+    expect(url).toContain("wind_speed_unit=mph");
+
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    const [cacheKey, , opts] = putSpy.mock.calls[0];
+    expect(String(cacheKey)).toBe("wx:37.17:-118.59");
+    expect((opts as { expirationTtl?: number } | undefined)?.expirationTtl).toBe(3600);
+  });
+
+  test.each([
+    [0, "clear"],
+    [2, "partly cloudy"],
+    [45, "fog"],
+    [53, "drizzle"],
+    [63, "rain"],
+    [73, "snow"],
+    [81, "showers"],
+    [95, "thunderstorm"],
+  ])("WMO code %i maps to %s", async (code, label) => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(200, {
+        current: { temperature_2m: 50, wind_speed_10m: 0, weather_code: code },
+      }),
+    );
+    const result = await currentWeather(40, -100, env);
+    expect(result).toContain(label);
+  });
+});
+
+describe("currentWeather — error fallback", () => {
+  test("5xx → 'weather unavailable'", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(503, {}));
+    const result = await currentWeather(40, -100, env);
+    expect(result).toBe("weather unavailable");
+    const events = loggedEvents().map((e) => e.event);
+    expect(events).toContain("weather_failed");
+  });
+
+  test("network error → 'weather unavailable'", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("network"));
+    const result = await currentWeather(40, -100, env);
+    expect(result).toBe("weather unavailable");
+  });
+
+  test("malformed response (no current.temperature_2m) → fallback", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(200, { current: {} }));
+    const result = await currentWeather(40, -100, env);
+    expect(result).toBe("weather unavailable");
+  });
+});


### PR DESCRIPTION
## Summary

`currentWeather(lat, lon, env): Promise<string>` — short ≤30-char string like `"42°F, 8mph, clear"` for embedding in 320-char SMS replies.

Closes #46.

### Caching

- Key: `wx:<lat:2>:<lon:2>` — 2-decimal-degree grid (~1km cells)
- TTL: 1 hour
- Hit-first; weather doesn't change second-by-second so this is generous.

### Open-Meteo

Free, no API key. URL:
```
https://api.open-meteo.com/v1/forecast
  ?latitude=&longitude=
  &current=temperature_2m,wind_speed_10m,weather_code
  &temperature_unit=fahrenheit&wind_speed_unit=mph
```

Imperial units by default (PRD personas span US/Iceland/Patagonia; preference toggle is a Phase 2 concern).

### WMO mapping

| Code | Label |
|---|---|
| 0 | clear |
| 1–3 | partly cloudy |
| 45, 48 | fog |
| 51–57 | drizzle |
| 61–67 | rain |
| 71–77 | snow |
| 80–82 | showers |
| 95–99 | thunderstorm |

### Errors non-fatal

Any failure (network / 4xx / 5xx / malformed / missing fields) → log `weather_failed` with reason and return `"weather unavailable"`. Caller responsibility (per plan): never invoke when lat/lon are absent — orchestrator strips them in P1-01.

Branched off `main`.

## Unblocks

**P1-16** (`!post` enrichment) and **P1-17** (`!mail` enrichment).

## Test plan

- [x] 12 Vitest cases:
  - Cache hit returns stored value
  - Cache key rounds to 2 decimals
  - Clear-day fetch: URL params (incl. imperial unit overrides), ≤30-char formatted string, 1h TTL
  - 8 parameterized WMO code → label mapping checks
  - 5xx → fallback + log
  - Network error → fallback
  - Malformed response → fallback
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 38/38
- [ ] CI green