### PR TITLE
feat(idempotency): op-level checkpoints + withCheckpoint helper (P1-13)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,9 +2,14 @@ import { Hono } from "hono";
 import type { Env } from "./env.js";
 import { imeiAllowSet } from "./env.js";
 import type { GarminEnvelope, GarminEvent } from "./core/types.js";
-import { idempotencyKey, IDEMPOTENCY_TTL_SECONDS } from "./core/idempotency.js";
-import type { IdempotencyRecord } from "./core/idempotency.js";
-import { putJSON } from "./adapters/storage/kv.js";
+import {
+  idempotencyKey,
+  readRecord,
+  writeRecord,
+  withCheckpoint,
+  markCompleted,
+  markFailed,
+} from "./core/idempotency.js";
 import { log } from "./adapters/logging/worker-logs.js";
 import { parseCommand } from "./core/grammar.js";
 import { orchestrate } from "./core/orchestrator.js";
@@ -30,11 +35,13 @@ export function makeApp() {
   /**
    * Garmin IPC Outbound receiver.
    *
-   * Per PRD §4, §5 + plan P1-01:
+   * Per PRD §4, §5 + plan P1-01 + P1-13:
    *   1. Verify bearer token (static, configured on Garmin Portal Connect).
    *   2. Parse body as Garmin V2 envelope.
-   *   3. Per event: verify IMEI allowlist; compute idempotency key;
-   *      short-circuit on replay; write `received` record on first delivery.
+   *   3. Per event: verify IMEI allowlist; compute idempotency key; on
+   *      `status="completed"` replay short-circuit immediately. Other states
+   *      (received/processing/failed) fall through; per-op `withCheckpoint`
+   *      calls skip already-done sub-ops.
    *   4. Guard 1 — only `messageCode === 3` (Free Text) dispatches. SOS
    *      (`messageCode === 4`) is logged and dropped per PRD §1 ("not a
    *      safety system"). Position Reports (`messageCode === 0`) and other
@@ -84,10 +91,9 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
   }
 
   const key = await idempotencyKey(event);
-  const kvKey = `idem:${key}`;
 
-  const existing = await env.TS_IDEMPOTENCY.get(kvKey);
-  if (existing !== null) {
+  const existing = await readRecord(env, key);
+  if (existing?.status === "completed") {
     log({
       event: "idempotent_replay",
       level: "info",
@@ -98,13 +104,13 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
     return;
   }
 
-  const record: IdempotencyRecord = {
-    status: "received",
-    receivedAt: Date.now(),
-  };
-  await putJSON(env.TS_IDEMPOTENCY, kvKey, record, {
-    expirationTtl: IDEMPOTENCY_TTL_SECONDS,
-  });
+  // First delivery (or partial-progress replay): seed/refresh the record.
+  // Subsequent withCheckpoint calls and the terminal markCompleted/markFailed
+  // overwrite this entry, preserving any completedOps/opResults from a prior
+  // partial run.
+  if (!existing) {
+    await writeRecord(env, key, { status: "received", receivedAt: Date.now() });
+  }
 
   if (event.messageCode !== 3) {
     if (event.messageCode === 4) {
@@ -138,7 +144,8 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
       freeText: event.freeText ?? null,
       key,
     });
-    await trySendReply(event.imei, "Unknown command. Try !help", env);
+    await trySendReplyWithCheckpoint(env, key, event.imei, "Unknown command. Try !help");
+    await markCompleted(env, key);
     return;
   }
 
@@ -164,24 +171,36 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
       key,
     });
     body = `Error: ${msg.slice(0, 80)}`;
+    await markFailed(env, key, msg);
+    // Still try to deliver the error reply to the user, but don't mark
+    // completed — replay will retry orchestrate.
+    await trySendReplyWithCheckpoint(env, key, event.imei, body);
+    return;
   }
 
-  const replyOk = await trySendReply(event.imei, body, env);
+  const replyOk = await trySendReplyWithCheckpoint(env, key, event.imei, body);
   if (replyOk) {
-    const completed: IdempotencyRecord = {
-      status: "completed",
-      receivedAt: record.receivedAt,
-      completedAt: Date.now(),
-    };
-    await putJSON(env.TS_IDEMPOTENCY, kvKey, completed, {
-      expirationTtl: IDEMPOTENCY_TTL_SECONDS,
-    });
+    await markCompleted(env, key);
   }
 }
 
-async function trySendReply(imei: string, message: string, env: Env): Promise<boolean> {
+/**
+ * Wrap the IPC Inbound send in a withCheckpoint so a webhook replay after a
+ * successful send (but before markCompleted reached KV) doesn't double-send to
+ * the device. Returns true on first-call success or cache-hit replay; false on
+ * send failure.
+ */
+async function trySendReplyWithCheckpoint(
+  env: Env,
+  idemKey: string,
+  imei: string,
+  message: string,
+): Promise<boolean> {
   try {
-    await sendReply(imei, [message], env);
+    await withCheckpoint(env, idemKey, "reply", async () => {
+      await sendReply(imei, [message], env);
+      return { sentAt: Date.now() };
+    });
     return true;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -1,4 +1,8 @@
+import { z } from "zod";
+import type { Env } from "../env.js";
 import type { GarminEvent } from "./types.js";
+import { getJSON, putJSON } from "../adapters/storage/kv.js";
+import { log } from "../adapters/logging/worker-logs.js";
 
 /**
  * Idempotency key derivation (PRD §5).
@@ -30,13 +34,162 @@ export async function sha256Hex(input: string): Promise<string> {
 }
 
 /**
- * Message-lifecycle record stored under `idem:<key>` (PRD §5).
- * Phase 0 writes `status: "received"`; Phase 1 adds op-level checkpoints.
+ * Op names recognized by `withCheckpoint`. Locked to the α-MVP side-effecting
+ * steps so a typo doesn't silently create a new bucket. Add to this union as
+ * new ops appear (e.g. P3 `!camp`).
  */
-export interface IdempotencyRecord {
-  status: "received" | "processing" | "completed" | "failed";
-  receivedAt: number;
-  completedAt?: number;
-  completedOps?: string[];
-  error?: string;
+export type OpName = "narrative" | "publish" | "mail" | "todo" | "reply";
+
+/**
+ * Message-lifecycle record stored under `idem:<key>` (PRD §5).
+ *
+ *   received   — webhook accepted, before any side effects.
+ *   processing — at least one op started; intermediate state during a single
+ *                request lifecycle. Phase 0/1 don't write this directly; it's
+ *                reserved for replay scenarios where the worker died mid-flight.
+ *   completed  — terminal success. Replay short-circuits with no side effects.
+ *   failed     — terminal failure. Replay re-runs missing ops via withCheckpoint.
+ */
+export const IdempotencyRecordSchema = z.object({
+  status: z.enum(["received", "processing", "completed", "failed"]),
+  receivedAt: z.number(),
+  completedOps: z.array(z.string()).optional(),
+  opResults: z.record(z.unknown()).optional(),
+  completedAt: z.number().optional(),
+  failedAt: z.number().optional(),
+  error: z.string().optional(),
+});
+
+export type IdempotencyRecord = z.infer<typeof IdempotencyRecordSchema>;
+
+const kvKeyOf = (idemKey: string) => `idem:${idemKey}`;
+
+/**
+ * Read and zod-validate the record at `idem:<idemKey>`. Returns null if absent
+ * or if the stored shape fails validation (logged as `warn`). Treating shape
+ * drift as "absent" lets the next write reset the record cleanly — worst case
+ * one transaction's ops re-run after a deploy that changes the schema.
+ */
+export async function readRecord(env: Env, idemKey: string): Promise<IdempotencyRecord | null> {
+  const raw = await getJSON<unknown>(env.TS_IDEMPOTENCY, kvKeyOf(idemKey));
+  if (raw === null) return null;
+  const parsed = IdempotencyRecordSchema.safeParse(raw);
+  if (!parsed.success) {
+    log({
+      event: "idempotency_record_invalid",
+      level: "warn",
+      key: idemKey,
+      issues: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`),
+    });
+    return null;
+  }
+  return parsed.data;
+}
+
+/** Write a record back to KV with the standard 48h TTL. */
+export async function writeRecord(
+  env: Env,
+  idemKey: string,
+  record: IdempotencyRecord,
+): Promise<void> {
+  await putJSON(env.TS_IDEMPOTENCY, kvKeyOf(idemKey), record, {
+    expirationTtl: IDEMPOTENCY_TTL_SECONDS,
+  });
+}
+
+/**
+ * Wrap a side-effecting op so it runs at most once per idempotency key.
+ *
+ * On first call: invoke `fn`, JSON-serializability-test the result, append
+ * `opName` to `completedOps`, store the result in `opResults[opName]`, write
+ * back, return the result.
+ *
+ * On replay: if `opName` is already in `completedOps`, return the cached
+ * result without invoking `fn`. The cached value is the same object shape `fn`
+ * originally returned (after a JSON round-trip — see plain-language note).
+ *
+ * If `fn` throws, the record is NOT updated — the next replay will retry the op.
+ *
+ * **Plain-language note.** Cloudflare KV stores strings; we JSON-stringify on
+ * write and JSON.parse on read. So a cached `Date` comes back as an ISO string,
+ * a `Map` comes back as `{}`, and circular refs throw on stringify. The
+ * serializability check (`JSON.stringify` + `JSON.parse` round-trip) makes a
+ * non-serializable return value a hard error at the *first* call, instead of a
+ * silent corruption discovered during a 3am replay storm.
+ */
+export async function withCheckpoint<T>(
+  env: Env,
+  idemKey: string,
+  opName: OpName,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const record = await readRecord(env, idemKey);
+
+  if (record && record.completedOps?.includes(opName)) {
+    return record.opResults?.[opName] as T;
+  }
+
+  const result = await fn();
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(result);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `withCheckpoint: op "${opName}" returned non-JSON-serializable value (${msg}). ` +
+        `Cloudflare KV cannot store circular refs, BigInts, or functions; ` +
+        `narrow the return type before checkpointing.`,
+      { cause: err },
+    );
+  }
+  if (serialized === undefined) {
+    throw new Error(
+      `withCheckpoint: op "${opName}" returned undefined or a value that JSON.stringify ` +
+        `dropped (e.g. function, symbol). Return null for "no result" instead.`,
+    );
+  }
+  // Round-trip so the in-memory value matches what a future replay will see.
+  const roundTripped = JSON.parse(serialized) as T;
+
+  const base: IdempotencyRecord = record ?? {
+    status: "processing",
+    receivedAt: Date.now(),
+  };
+  const next: IdempotencyRecord = {
+    ...base,
+    status: base.status === "completed" ? "completed" : "processing",
+    completedOps: [...(base.completedOps ?? []), opName],
+    opResults: { ...(base.opResults ?? {}), [opName]: roundTripped },
+  };
+  await writeRecord(env, idemKey, next);
+
+  return roundTripped;
+}
+
+/** Mark the record as terminally failed. Idempotent — safe to call repeatedly. */
+export async function markFailed(env: Env, idemKey: string, error: string): Promise<void> {
+  const existing = await readRecord(env, idemKey);
+  const next: IdempotencyRecord = {
+    status: "failed",
+    receivedAt: existing?.receivedAt ?? Date.now(),
+    completedOps: existing?.completedOps,
+    opResults: existing?.opResults,
+    failedAt: Date.now(),
+    error,
+  };
+  await writeRecord(env, idemKey, next);
+}
+
+/** Mark the record as terminally completed. */
+export async function markCompleted(env: Env, idemKey: string): Promise<void> {
+  const existing = await readRecord(env, idemKey);
+  const next: IdempotencyRecord = {
+    status: "completed",
+    receivedAt: existing?.receivedAt ?? Date.now(),
+    completedOps: existing?.completedOps,
+    opResults: existing?.opResults,
+    completedAt: Date.now(),
+  };
+  await writeRecord(env, idemKey, next);
 }

--- a/tests/idempotency.test.ts
+++ b/tests/idempotency.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  IDEMPOTENCY_TTL_SECONDS,
+  IdempotencyRecordSchema,
+  markCompleted,
+  markFailed,
+  readRecord,
+  withCheckpoint,
+  writeRecord,
+} from "../src/core/idempotency.js";
+import type { Env } from "../src/env.js";
+import { kvSize, makeTestEnv } from "./helpers/env.js";
+
+const KEY = "abc123";
+const KV_KEY = `idem:${KEY}`;
+
+let env: Env;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  env = makeTestEnv();
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("readRecord — zod validation on read", () => {
+  test("returns null when key is absent", async () => {
+    expect(await readRecord(env, KEY)).toBeNull();
+  });
+
+  test("parses a valid record", async () => {
+    await writeRecord(env, KEY, { status: "received", receivedAt: 1700000000 });
+    const rec = await readRecord(env, KEY);
+    expect(rec).toEqual({ status: "received", receivedAt: 1700000000 });
+  });
+
+  test("returns null and logs warn when stored shape is invalid", async () => {
+    // Bypass writeRecord to plant a stale-shape record (status missing).
+    await env.TS_IDEMPOTENCY.put(KV_KEY, JSON.stringify({ receivedAt: 1, foo: "bar" }));
+
+    const rec = await readRecord(env, KEY);
+    expect(rec).toBeNull();
+
+    const warned = errSpy.mock.calls
+      .map((c) => JSON.parse(String(c[0])) as { event: string })
+      .some((e) => e.event === "idempotency_record_invalid");
+    expect(warned).toBe(true);
+  });
+});
+
+describe("writeRecord — TTL", () => {
+  test("writes with the 48h expirationTtl", async () => {
+    const putSpy = vi.spyOn(env.TS_IDEMPOTENCY, "put");
+    await writeRecord(env, KEY, { status: "received", receivedAt: 1 });
+
+    const opts = putSpy.mock.calls[0][2] as { expirationTtl?: number } | undefined;
+    expect(opts?.expirationTtl).toBe(IDEMPOTENCY_TTL_SECONDS);
+  });
+});
+
+describe("withCheckpoint — first-call vs replay", () => {
+  test("first call invokes fn, stores result, appends to completedOps", async () => {
+    const fn = vi.fn(async () => ({ url: "https://example.com/post/1" }));
+
+    const result = await withCheckpoint(env, KEY, "publish", fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ url: "https://example.com/post/1" });
+
+    const rec = await readRecord(env, KEY);
+    expect(rec?.completedOps).toEqual(["publish"]);
+    expect(rec?.opResults).toEqual({ publish: { url: "https://example.com/post/1" } });
+    expect(rec?.status).toBe("processing");
+  });
+
+  test("replay returns cached result without invoking fn", async () => {
+    const fn = vi.fn(async () => ({ url: "first" }));
+
+    const first = await withCheckpoint(env, KEY, "publish", fn);
+    expect(first).toEqual({ url: "first" });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // A second call (replay) — fn should NOT be invoked again.
+    const replayFn = vi.fn(async () => ({ url: "second" }));
+    const replay = await withCheckpoint(env, KEY, "publish", replayFn);
+
+    expect(replayFn).not.toHaveBeenCalled();
+    expect(replay).toEqual({ url: "first" });
+
+    // Only one entry in KV and only one completedOp.
+    expect(kvSize(env.TS_IDEMPOTENCY)).toBe(1);
+    const rec = await readRecord(env, KEY);
+    expect(rec?.completedOps).toEqual(["publish"]);
+  });
+
+  test("when fn throws, completedOps is NOT updated and the error propagates", async () => {
+    const boom = new Error("OpenRouter 502");
+    const fn = vi.fn(async () => {
+      throw boom;
+    });
+
+    await expect(withCheckpoint(env, KEY, "narrative", fn)).rejects.toBe(boom);
+
+    const rec = await readRecord(env, KEY);
+    expect(rec?.completedOps ?? []).toEqual([]);
+    expect(rec?.opResults ?? {}).toEqual({});
+  });
+
+  test("multiple ops accumulate independently in completedOps and opResults", async () => {
+    await withCheckpoint(env, KEY, "narrative", async () => ({ title: "T", haiku: "H", body: "B" }));
+    await withCheckpoint(env, KEY, "publish", async () => ({ url: "U" }));
+
+    const rec = await readRecord(env, KEY);
+    expect(rec?.completedOps).toEqual(["narrative", "publish"]);
+    expect(rec?.opResults).toEqual({
+      narrative: { title: "T", haiku: "H", body: "B" },
+      publish: { url: "U" },
+    });
+  });
+
+  test("non-JSON-serializable return value throws a clear error", async () => {
+    // Map values become {} after JSON round-trip — flag at first call.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await expect(
+      withCheckpoint(env, KEY, "narrative", async () => circular),
+    ).rejects.toThrow(/non-JSON-serializable/);
+
+    // Record was not corrupted by the failed op.
+    const rec = await readRecord(env, KEY);
+    expect(rec?.completedOps ?? []).toEqual([]);
+  });
+
+  test("fn returning undefined throws (use null for 'no result')", async () => {
+    await expect(
+      withCheckpoint(env, KEY, "reply", async () => undefined),
+    ).rejects.toThrow(/undefined/);
+  });
+
+  test("preserves completedAt when called after markCompleted (idempotent terminal state)", async () => {
+    // A completed record has terminal status — withCheckpoint on a new op
+    // should not regress it back to "processing".
+    await withCheckpoint(env, KEY, "narrative", async () => ({ ok: true }));
+    await markCompleted(env, KEY);
+
+    const before = await readRecord(env, KEY);
+    expect(before?.status).toBe("completed");
+
+    // A subsequent (rare, post-completion) checkpoint call must not flip status.
+    await withCheckpoint(env, KEY, "publish", async () => ({ also: true }));
+    const after = await readRecord(env, KEY);
+    expect(after?.status).toBe("completed");
+    expect(after?.completedOps).toEqual(["narrative", "publish"]);
+  });
+});
+
+describe("withCheckpoint — JSON round-trip semantics", () => {
+  test("Date returns survive as ISO strings (cached value matches what replay sees)", async () => {
+    const fn = vi.fn(async () => ({ when: new Date("2026-04-25T00:00:00Z") }));
+    const result = await withCheckpoint(env, KEY, "narrative", fn);
+
+    // After round-trip, Date becomes a string. Caller code receiving the
+    // first-call return gets the same shape replay would see.
+    const when = (result as unknown as { when: unknown }).when;
+    expect(typeof when).toBe("string");
+    expect(when).toBe("2026-04-25T00:00:00.000Z");
+  });
+});
+
+describe("markFailed", () => {
+  test("sets status='failed', failedAt, error; preserves completedOps", async () => {
+    await withCheckpoint(env, KEY, "narrative", async () => ({ ok: true }));
+    await markFailed(env, KEY, "Resend 503");
+
+    const rec = await readRecord(env, KEY);
+    expect(rec?.status).toBe("failed");
+    expect(typeof rec?.failedAt).toBe("number");
+    expect(rec?.error).toBe("Resend 503");
+    expect(rec?.completedOps).toEqual(["narrative"]);
+  });
+
+  test("safe to call when no record exists yet", async () => {
+    await markFailed(env, KEY, "early-fail");
+    const rec = await readRecord(env, KEY);
+    expect(rec?.status).toBe("failed");
+    expect(rec?.error).toBe("early-fail");
+  });
+});
+
+describe("acceptance-criteria #8 — !post pipeline replay scenario", () => {
+  test("succeeds at narrative + publish, fails at reply; replay re-runs only reply", async () => {
+    const narrativeFn = vi.fn(async () => ({ title: "Lake basin", haiku: "...", body: "..." }));
+    const publishFn = vi.fn(async () => ({ url: "https://blog/post/1" }));
+
+    let replyAttempt = 0;
+    const replyFn = vi.fn(async () => {
+      replyAttempt += 1;
+      if (replyAttempt === 1) throw new Error("Garmin 503");
+      return { sentAt: 99 };
+    });
+
+    // Run 1 — narrative + publish succeed; reply throws.
+    await withCheckpoint(env, KEY, "narrative", narrativeFn);
+    await withCheckpoint(env, KEY, "publish", publishFn);
+    await expect(withCheckpoint(env, KEY, "reply", replyFn)).rejects.toThrow(/Garmin 503/);
+
+    expect(narrativeFn).toHaveBeenCalledTimes(1);
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    expect(replyFn).toHaveBeenCalledTimes(1);
+
+    let rec = await readRecord(env, KEY);
+    expect(rec?.completedOps).toEqual(["narrative", "publish"]);
+
+    // Run 2 (replay) — same key, same ops in same order.
+    await withCheckpoint(env, KEY, "narrative", narrativeFn);
+    await withCheckpoint(env, KEY, "publish", publishFn);
+    await withCheckpoint(env, KEY, "reply", replyFn);
+
+    // narrative + publish must NOT be re-invoked — total still 1 each.
+    expect(narrativeFn).toHaveBeenCalledTimes(1);
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    // reply was retried — total is now 2.
+    expect(replyFn).toHaveBeenCalledTimes(2);
+
+    rec = await readRecord(env, KEY);
+    expect(rec?.completedOps).toEqual(["narrative", "publish", "reply"]);
+    expect(rec?.opResults?.reply).toEqual({ sentAt: 99 });
+  });
+});
+
+describe("IdempotencyRecordSchema — type safety smoke", () => {
+  test("accepts a fully-populated record", () => {
+    const ok = IdempotencyRecordSchema.safeParse({
+      status: "completed",
+      receivedAt: 1,
+      completedAt: 2,
+      completedOps: ["narrative", "publish", "reply"],
+      opResults: { narrative: {}, publish: {}, reply: {} },
+    });
+    expect(ok.success).toBe(true);
+  });
+
+  test("rejects unknown status", () => {
+    const bad = IdempotencyRecordSchema.safeParse({ status: "weird", receivedAt: 1 });
+    expect(bad.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `src/core/idempotency.ts` with a zod-validated record shape (`completedOps` + `opResults` + `failedAt`) and a `withCheckpoint(env, idemKey, opName, fn)` helper so command pipelines can replay-safely skip already-done sub-ops (LLM call, blog commit, email send, task create, reply send).
- Refactor `src/app.ts` to use `readRecord` / `writeRecord` / `markCompleted` / `markFailed`. Replay short-circuit now keys on `status === "completed"` rather than "key exists", so partial-progress records (received/processing/failed) fall through and `withCheckpoint` calls in command handlers can skip already-done ops.
- Wrap the IPC Inbound reply send in `withCheckpoint("reply", …)` so a webhook replay after a successful send doesn't double-deliver to the device.
- 17 new tests in `tests/idempotency.test.ts` covering all 8 acceptance criteria, including the full `!post` replay scenario (acceptance #8): narrative + publish succeed, reply throws, replay re-runs only reply.

Closes #49.

## Design notes

- **`readRecord` returns null + warns on shape drift** rather than throwing. Lets the next write reset cleanly across schema-changing deploys; worst case is one transaction's ops re-run.
- **`withCheckpoint` JSON-round-trips the first-call return** so the in-memory value matches what a future replay reads from KV (Date → ISO string, Map → `{}`, etc.). Non-serializable returns throw at the first call, not at 3am.
- **`markCompleted` / `markFailed` own terminal state** — `withCheckpoint` never flips status to "completed" itself, since it has no way to know if it's the last op in the pipeline.
- **No CAS in Cloudflare KV** — the read-modify-write per call is technically racy, but Garmin's retry cadence is sequential per device (the 2/4/8/16s plateau), so concurrent replay of the *same idempotency key* is not a realistic α-MVP scenario. Phase 3's Durable Objects fix this for real.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 115 passing (98 baseline + 17 new)
- [ ] CI green on PR
- [ ] Smoke-tested in next P1-19 / P1-16 PR (real command pipelines compose `withCheckpoint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)