### PR TITLE
feat(reply): 320-char reply builder with two-SMS paging (P1-15)

### DIFF
--- a/src/core/reply.ts
+++ b/src/core/reply.ts
@@ -1,0 +1,102 @@
+import type { Env } from "../env.js";
+import { appendCostSuffix } from "../env.js";
+import { buildGoogleMapsLink, buildMapShareLink } from "./links.js";
+
+/**
+ * Iridium SBD hard limit per message — Garmin IPC Inbound returns 422
+ * `InvalidMessageError` on overage (PRD §3, Garmin IPC Inbound v3.1.1).
+ */
+export const SMS_MAX = 160;
+
+/** Page marker: 5 chars, glued to the end of each page (no leading space). */
+const MARKER_LEN = 5;
+
+export interface BuildReplyArgs {
+  body: string;
+  lat?: number;
+  lon?: number;
+  costUsdMtd?: number;
+  env: Env;
+}
+
+/**
+ * Build a 1- or 2-string reply respecting the 320-char total budget and the
+ * 160-char per-SMS hard cap (PRD §3 + plan P1-15).
+ *
+ * - Map links are appended to the page that has room when `lat`/`lon` are
+ *   defined. When undefined (no GPS fix), no link is emitted — including no
+ *   `?q=0,0` placeholder.
+ * - The cost suffix `· $X.XX` is appended to the *last* page when
+ *   `APPEND_COST_SUFFIX=true` and `costUsdMtd` is provided.
+ * - On overflow (body + extras + markers > 320), `body` is truncated; the
+ *   extras and markers are preserved (caller's choice to enable cost suffix /
+ *   GPS-rich reply takes precedence over body completeness).
+ *
+ * Throws if any output page exceeds {@link SMS_MAX} — that's a caller bug
+ * (logic mistake here, not a runtime input error).
+ */
+export function buildReply({ body, lat, lon, costUsdMtd, env }: BuildReplyArgs): string[] {
+  const hasGps = lat !== undefined && lon !== undefined;
+  const mapsLink = hasGps ? buildGoogleMapsLink(lat, lon, env) : "";
+  const mapShareLink = hasGps ? buildMapShareLink(lat, lon, env) : "";
+  const costSuffix =
+    appendCostSuffix(env) && typeof costUsdMtd === "number"
+      ? ` · $${costUsdMtd.toFixed(2)}`
+      : "";
+
+  // Tail composition: leading-space-separated tokens. Empty pieces drop out.
+  const tailPieces = [mapsLink, mapShareLink].filter((s) => s.length > 0);
+  const linksTail = tailPieces.length > 0 ? " " + tailPieces.join(" ") : "";
+  const tail = linksTail + costSuffix;
+
+  // Single-page case: body + tail fits within 160 with no marker overhead.
+  if (body.length + tail.length <= SMS_MAX) {
+    const single = body + tail;
+    assertWithinLimit(single);
+    return [single];
+  }
+
+  // Two-page case. Page 1 carries body only; page 2 carries body remainder
+  // + tail + marker. Markers are 5 chars each.
+  const page1Budget = SMS_MAX - MARKER_LEN; // 155
+  const page2BodyBudget = SMS_MAX - MARKER_LEN - tail.length;
+
+  const head = body.slice(0, page1Budget);
+  let remainder = body.slice(page1Budget);
+
+  // If the remainder + tail still won't fit on page 2, truncate the remainder
+  // (preserving tail per spec).
+  if (remainder.length > page2BodyBudget) {
+    remainder = remainder.slice(0, Math.max(0, page2BodyBudget));
+  }
+
+  // If page2BodyBudget is negative (tail alone > 155), the tail is too big
+  // to fit even with markers — that's a configuration bug (e.g. enormous
+  // MAPSHARE_BASE URL). Fail loudly so we catch it in tests, not in the
+  // field where Garmin would 422 the send.
+  if (page2BodyBudget < 0) {
+    throw new Error(
+      `buildReply: extras tail (${tail.length} chars) leaves no room for body on page 2 ` +
+        `(SMS_MAX=${SMS_MAX}, marker=${MARKER_LEN}). Shorten MAPSHARE_BASE or disable links.`,
+    );
+  }
+
+  const page1 = head + "(1/2)";
+
+  // If remainder is empty and tail starts with a space, strip it — avoids
+  // "  https://..." with a leading double-space when body fully fits page 1.
+  const page2Body = remainder.length > 0 ? remainder + tail : tail.trimStart();
+  const page2 = page2Body + "(2/2)";
+
+  assertWithinLimit(page1);
+  assertWithinLimit(page2);
+  return [page1, page2];
+}
+
+function assertWithinLimit(s: string): void {
+  if (s.length > SMS_MAX) {
+    throw new Error(
+      `buildReply produced a ${s.length}-char page (limit ${SMS_MAX}). Caller bug.`,
+    );
+  }
+}

--- a/tests/reply.test.ts
+++ b/tests/reply.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+
+import { buildReply, SMS_MAX } from "../src/core/reply.js";
+import type { Env } from "../src/env.js";
+import { makeTestEnv } from "./helpers/env.js";
+
+const LAT = 37.1682;
+const LON = -118.5891;
+
+function envWith(overrides: Partial<Env> = {}): Env {
+  return makeTestEnv({
+    GOOGLE_MAPS_BASE: "https://www.google.com/maps/search/?api=1&query=",
+    MAPSHARE_BASE: "https://share.garmin.com/MyMap",
+    APPEND_COST_SUFFIX: "false",
+    ...overrides,
+  });
+}
+
+describe("buildReply — single page", () => {
+  test("short body, no GPS, no cost suffix → 1 page, body verbatim", () => {
+    const out = buildReply({ body: "pong", env: envWith() });
+    expect(out).toEqual(["pong"]);
+  });
+
+  test("body + GPS links fit ≤ 160 → 1 page with both links appended", () => {
+    const out = buildReply({ body: "ok", lat: LAT, lon: LON, env: envWith() });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("ok");
+    expect(out[0]).toContain("https://www.google.com/maps/search/?api=1&query=37.1682,-118.5891");
+    expect(out[0]).toContain("https://share.garmin.com/MyMap?d=37.1682,-118.5891");
+    expect(out[0].length).toBeLessThanOrEqual(SMS_MAX);
+  });
+
+  test("APPEND_COST_SUFFIX=true with costUsdMtd → suffix appended", () => {
+    const out = buildReply({
+      body: "pong",
+      costUsdMtd: 0.05,
+      env: envWith({ APPEND_COST_SUFFIX: "true" }),
+    });
+    expect(out).toEqual(["pong · $0.05"]);
+  });
+
+  test("APPEND_COST_SUFFIX=false but costUsdMtd provided → suffix NOT emitted", () => {
+    const out = buildReply({
+      body: "pong",
+      costUsdMtd: 0.05,
+      env: envWith({ APPEND_COST_SUFFIX: "false" }),
+    });
+    expect(out).toEqual(["pong"]);
+  });
+
+  test("APPEND_COST_SUFFIX=true but costUsdMtd undefined → no suffix", () => {
+    const out = buildReply({
+      body: "pong",
+      env: envWith({ APPEND_COST_SUFFIX: "true" }),
+    });
+    expect(out).toEqual(["pong"]);
+  });
+});
+
+describe("buildReply — GPS absence", () => {
+  test("lat/lon undefined → no map link, NO `?q=0,0` placeholder", () => {
+    const out = buildReply({ body: "no fix yet", env: envWith() });
+    expect(out).toEqual(["no fix yet"]);
+    expect(out[0]).not.toContain("?q=");
+    expect(out[0]).not.toContain("?api=1");
+    expect(out[0]).not.toContain("share.garmin.com");
+  });
+
+  test("only one of lat/lon provided → treated as no GPS", () => {
+    // Both fields are optional in the type; this asserts the runtime guard.
+    const out = buildReply({ body: "x", lat: LAT, env: envWith() });
+    expect(out).toEqual(["x"]);
+  });
+});
+
+describe("buildReply — MapShare gating", () => {
+  test("MAPSHARE_BASE empty → only Google Maps link emitted", () => {
+    const out = buildReply({
+      body: "ok",
+      lat: LAT,
+      lon: LON,
+      env: envWith({ MAPSHARE_BASE: "" }),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("https://www.google.com/maps");
+    expect(out[0]).not.toContain("share.garmin.com");
+  });
+});
+
+describe("buildReply — two-page paging", () => {
+  test("body 200 chars → split into two pages with (1/2)/(2/2) markers", () => {
+    const body = "x".repeat(200);
+    const out = buildReply({ body, env: envWith() });
+
+    expect(out).toHaveLength(2);
+    expect(out[0].endsWith("(1/2)")).toBe(true);
+    expect(out[1].endsWith("(2/2)")).toBe(true);
+    expect(out[0].length).toBeLessThanOrEqual(SMS_MAX);
+    expect(out[1].length).toBeLessThanOrEqual(SMS_MAX);
+
+    // Reassembled body (minus markers) preserves all 200 characters.
+    const reassembled = out[0].slice(0, -5) + out[1].slice(0, -5);
+    expect(reassembled).toBe(body);
+  });
+
+  test("body + GPS links overflow 160 → 2 pages, links on page 2", () => {
+    const body = "Lake Sabrina basin, granite walls glowing in alpenglow at sunset.";
+    const out = buildReply({ body, lat: LAT, lon: LON, env: envWith() });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).not.toContain("google.com");
+    expect(out[1]).toContain("https://www.google.com/maps");
+    expect(out[1]).toContain("https://share.garmin.com/MyMap");
+    expect(out[0].length).toBeLessThanOrEqual(SMS_MAX);
+    expect(out[1].length).toBeLessThanOrEqual(SMS_MAX);
+  });
+
+  test("body + GPS + cost suffix → 2 pages, both extras land on last page", () => {
+    const body = "Lake Sabrina basin, granite walls glowing in alpenglow at sunset.";
+    const out = buildReply({
+      body,
+      lat: LAT,
+      lon: LON,
+      costUsdMtd: 0.42,
+      env: envWith({ APPEND_COST_SUFFIX: "true" }),
+    });
+
+    expect(out).toHaveLength(2);
+    expect(out[1]).toContain("google.com");
+    expect(out[1]).toContain("· $0.42");
+    expect(out[0].length).toBeLessThanOrEqual(SMS_MAX);
+    expect(out[1].length).toBeLessThanOrEqual(SMS_MAX);
+  });
+});
+
+describe("buildReply — overflow handling (body too long, extras preserved)", () => {
+  test("very long body with GPS + cost suffix → body truncated, extras + markers preserved", () => {
+    const body = "Z".repeat(400);
+    const out = buildReply({
+      body,
+      lat: LAT,
+      lon: LON,
+      costUsdMtd: 0.99,
+      env: envWith({ APPEND_COST_SUFFIX: "true" }),
+    });
+
+    expect(out).toHaveLength(2);
+    expect(out[0].endsWith("(1/2)")).toBe(true);
+    expect(out[1].endsWith("(2/2)")).toBe(true);
+    // Extras preserved verbatim on page 2.
+    expect(out[1]).toContain("https://www.google.com/maps");
+    expect(out[1]).toContain("https://share.garmin.com/MyMap");
+    expect(out[1]).toContain("· $0.99");
+    expect(out[0].length).toBeLessThanOrEqual(SMS_MAX);
+    expect(out[1].length).toBeLessThanOrEqual(SMS_MAX);
+
+    // Body was truncated (we lost some Z's at the tail).
+    const reassembledBody = out[0].slice(0, -5) + out[1].slice(0, out[1].lastIndexOf(" "));
+    expect(reassembledBody.length).toBeLessThan(400);
+    expect(reassembledBody.startsWith("Z")).toBe(true);
+  });
+
+  test("body fits page 1 exactly (155 chars) + extras → page 2 has no leading double-space", () => {
+    // 155 chars body fills page 1 exactly; remainder is empty so the leading
+    // space on the maps tail must be stripped.
+    const body = "a".repeat(155);
+    const out = buildReply({ body, lat: LAT, lon: LON, env: envWith() });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe("a".repeat(155) + "(1/2)");
+    expect(out[1]).not.toMatch(/^\s/);
+    expect(out[1].startsWith("https://")).toBe(true);
+    expect(out[1].endsWith("(2/2)")).toBe(true);
+  });
+});
+
+describe("buildReply — assertion guard", () => {
+  test("each output page is ≤ 160 across a range of input sizes", () => {
+    // Property-style spot-check: body lengths 0..400 step 7, with + without GPS.
+    for (let n = 0; n <= 400; n += 7) {
+      const body = "b".repeat(n);
+      for (const gps of [false, true]) {
+        const out = buildReply({
+          body,
+          lat: gps ? LAT : undefined,
+          lon: gps ? LON : undefined,
+          env: envWith(),
+        });
+        for (const page of out) {
+          expect(page.length).toBeLessThanOrEqual(SMS_MAX);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/core/reply.ts` exports `buildReply({ body, lat?, lon?, costUsdMtd?, env }): string[]` — returns 1 or 2 strings each ≤ 160 chars (the Iridium SBD hard limit).
- Single-page rule: body + map links + cost suffix all fit on one message → return 1 string.
- Two-page case: page-split with `(1/2)`/`(2/2)` markers (5 chars each). Map links + cost suffix always land on the last page so users see them regardless of pagination.
- GPS-absent path emits no map link at all — no `?q=0,0` placeholder. `MAPSHARE_BASE` empty drops only the mapshare link.
- On overflow (body + extras > 320), body is truncated; extras + markers preserved per spec.
- Each output page asserted ≤ 160 (throws on violation — caller bug).

Closes #51.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 129 passing (115 baseline + 14 new)
- [ ] CI green on PR
- [ ] Smoke-tested in P1-19 PR (`!ping`/`!help`/`!cost` real reply paths) and P1-16/17/18 (command pipelines)

## Spec quirks worth flagging

- **Page marker is 5 chars (`(1/2)`) glued to body, no leading space** — follows plan §P1-15 literally. Reads slightly mashed (`...the basin.(1/2)`); easy to switch to 6-char ` (1/2)` if you'd rather, but rebudgets all the math.
- **Plan said `buildMapShareLink(env)`**, actual signature is `buildMapShareLink(lat, lon, env)`. Used the actual one.
- **Char-counted, not byte-counted**: assumes ASCII-only output. If we ever emit non-ASCII (the `· $X.XX` middle dot is a 2-byte UTF-8 char, but that's a fixed string), the assertion would need a byte-length check. P3 problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)