### PR TITLE
feat(commands): real !ping/!help/!cost reply paths (P1-19)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "./env.js";
-import { imeiAllowSet } from "./env.js";
-import type { GarminEnvelope, GarminEvent } from "./core/types.js";
+import { appendCostSuffix, imeiAllowSet } from "./env.js";
+import type { CommandResult, GarminEnvelope, GarminEvent } from "./core/types.js";
 import {
   idempotencyKey,
   readRecord,
@@ -14,6 +14,8 @@ import { log } from "./adapters/logging/worker-logs.js";
 import { parseCommand } from "./core/grammar.js";
 import { orchestrate } from "./core/orchestrator.js";
 import { sendReply } from "./adapters/outbound/garmin-ipc-inbound.js";
+import { buildReply } from "./core/reply.js";
+import { monthlyTotals } from "./core/ledger.js";
 
 /**
  * Hono app factory. Lives in its own module so tests can call `makeApp()`
@@ -144,15 +146,15 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
       freeText: event.freeText ?? null,
       key,
     });
-    await trySendReplyWithCheckpoint(env, key, event.imei, "Unknown command. Try !help");
+    const messages = buildReply({ body: "Unknown command. Try !help", env });
+    await trySendReplyWithCheckpoint(env, key, event.imei, messages);
     await markCompleted(env, key);
     return;
   }
 
-  let body: string;
+  let result: CommandResult;
   try {
-    const result = await orchestrate(command, { env, imei: event.imei, lat, lon });
-    body = result.body;
+    result = await orchestrate(command, { env, imei: event.imei, lat, lon });
     log({
       event: "orchestrate_ok",
       level: "info",
@@ -170,15 +172,30 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
       error: msg,
       key,
     });
-    body = `Error: ${msg.slice(0, 80)}`;
     await markFailed(env, key, msg);
+    const errMessages = buildReply({ body: `Error: ${msg.slice(0, 80)}`, env });
     // Still try to deliver the error reply to the user, but don't mark
     // completed — replay will retry orchestrate.
-    await trySendReplyWithCheckpoint(env, key, event.imei, body);
+    await trySendReplyWithCheckpoint(env, key, event.imei, errMessages);
     return;
   }
 
-  const replyOk = await trySendReplyWithCheckpoint(env, key, event.imei, body);
+  // The cost suffix is opt-in; only read the ledger when the flag is on, to
+  // save the KV round-trip on every reply. The orchestrator already updated
+  // the ledger for !ping et al, so this read sees the just-written total.
+  const costUsdMtd = appendCostSuffix(env)
+    ? (await monthlyTotals(env)).usd_cost
+    : undefined;
+
+  const messages = buildReply({
+    body: result.body,
+    lat: result.lat,
+    lon: result.lon,
+    costUsdMtd,
+    env,
+  });
+
+  const replyOk = await trySendReplyWithCheckpoint(env, key, event.imei, messages);
   if (replyOk) {
     await markCompleted(env, key);
   }
@@ -187,18 +204,18 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
 /**
  * Wrap the IPC Inbound send in a withCheckpoint so a webhook replay after a
  * successful send (but before markCompleted reached KV) doesn't double-send to
- * the device. Returns true on first-call success or cache-hit replay; false on
- * send failure.
+ * the device. Takes a pre-built page array (1 or 2 entries) from buildReply.
+ * Returns true on first-call success or cache-hit replay; false on send failure.
  */
 async function trySendReplyWithCheckpoint(
   env: Env,
   idemKey: string,
   imei: string,
-  message: string,
+  messages: string[],
 ): Promise<boolean> {
   try {
     await withCheckpoint(env, idemKey, "reply", async () => {
-      await sendReply(imei, [message], env);
+      await sendReply(imei, messages, env);
       return { sentAt: Date.now() };
     });
     return true;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,5 +1,6 @@
 import type { ParsedCommand, CommandResult } from "./types.js";
 import type { Env } from "../env.js";
+import { monthlyTotals, recordTransaction, type LedgerSnapshot } from "./ledger.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -11,25 +12,31 @@ export interface OrchestratorContext {
 /**
  * Dispatch a parsed command to its handler.
  *
- * Phase 0: not wired to the Worker fetch path. `ping` / `help` / `cost` return
- * real replies; `post` / `mail` / `todo` return a canned "not implemented in α"
- * string until Phase 1 fills in the adapters.
- *
- * Phase 1 adds: budget gate (reject expensive commands over DAILY_TOKEN_BUDGET),
- * idempotency op-level checkpoints (skip already-completed sub-ops on replay),
- * context rolling window writes.
+ * Phase 1 (P1-19): `!ping`/`!help`/`!cost` return real bodies; `!ping` records
+ * a 0-cost transaction in the ledger so it counts toward `!cost` totals;
+ * `!cost` reads `monthlyTotals(env)` and formats it. The post/mail/todo handlers
+ * remain canned until P1-16/17/18 wire their adapter pipelines.
  */
 export async function orchestrate(
   command: ParsedCommand,
-  _ctx: OrchestratorContext,
+  ctx: OrchestratorContext,
 ): Promise<CommandResult> {
   switch (command.type) {
     case "ping":
-      return { body: "pong" };
+      await recordTransaction({
+        command: "ping",
+        usage: { prompt_tokens: 0, completion_tokens: 0 },
+        env: ctx.env,
+      });
+      // Propagate GPS into the reply so the device confirms its fix on
+      // first commission test. Map links land on whichever page has room.
+      return { body: "pong", lat: ctx.lat, lon: ctx.lon };
     case "help":
       return { body: helpText() };
-    case "cost":
-      return { body: "0 req · 0 tok · $0.00 (Phase 1 wires real ledger)" };
+    case "cost": {
+      const snap = await monthlyTotals(ctx.env);
+      return { body: formatCostBody(snap) };
+    }
     case "post":
       return { body: "α: !post not yet implemented (Phase 1)" };
     case "mail":
@@ -51,4 +58,18 @@ function helpText(): string {
     "!cost — usage",
     "!help",
   ].join("\n");
+}
+
+/**
+ * Format the `!cost` reply body. Per plan P1-19:
+ *   "<requests> req · <tokens>k tok · $<cost> (since <YYYY-MM-01>)"
+ * Tokens are summed (prompt + completion) and rendered in thousands with one
+ * decimal. Total width capped at ~52 chars in realistic ranges.
+ */
+function formatCostBody(snap: LedgerSnapshot): string {
+  const totalTokens = snap.prompt_tokens + snap.completion_tokens;
+  const tokensK = (totalTokens / 1000).toFixed(1);
+  const cost = snap.usd_cost.toFixed(2);
+  const sinceDate = `${snap.period}-01`;
+  return `${snap.requests} req · ${tokensK}k tok · $${cost} (since ${sinceDate})`;
 }

--- a/tests/p1-19-commands.test.ts
+++ b/tests/p1-19-commands.test.ts
@@ -1,0 +1,213 @@
+/**
+ * P1-19 — End-to-end integration tests for !ping, !help, !cost.
+ *
+ * Drives the Worker via app.request(...) with a real orchestrator and a
+ * mocked sendReply. Asserts:
+ *   - Each command's body content matches the spec.
+ *   - sendReply receives the buildReply'd page array.
+ *   - !ping records a 0-cost transaction visible to !cost.
+ *   - GPS-bearing !ping picks up map links via buildReply.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals, recordTransaction } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({ MAPSHARE_BASE: "https://share.garmin.com/MyMap" });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+function envelope(freeText: string, opts: { ts?: number; gps?: { lat: number; lon: number } } = {}) {
+  const point = opts.gps
+    ? { latitude: opts.gps.lat, longitude: opts.gps.lon, altitude: 1000, gpsFix: 2 }
+    : { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 };
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? Date.now(),
+        point,
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("P1-19 — !ping", () => {
+  test("returns 'pong' as a single-page reply, no GPS → no map link", async () => {
+    const res = await postIpc(envelope("!ping"));
+    expect(res.status).toBe(200);
+
+    expect(sendReplyMock).toHaveBeenCalledTimes(1);
+    const [imei, messages] = sendReplyMock.mock.calls[0];
+    expect(imei).toBe("123456789012345");
+    expect(messages).toEqual(["pong"]);
+  });
+
+  test("with GPS fix → reply includes Google Maps + MapShare links on the same page", async () => {
+    const res = await postIpc(
+      envelope("!ping", { gps: { lat: 37.1682, lon: -118.5891 } }),
+    );
+    expect(res.status).toBe(200);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("pong");
+    expect(messages[0]).toContain("https://www.google.com/maps");
+    expect(messages[0]).toContain("https://share.garmin.com/MyMap");
+  });
+
+  test("records a 0-cost transaction in the ledger", async () => {
+    await postIpc(envelope("!ping"));
+    await postIpc(envelope("!ping", { ts: Date.now() + 1 })); // distinct idem key
+
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(2);
+    expect(snap.usd_cost).toBe(0);
+    expect(snap.by_command["ping"]).toEqual({ requests: 2, usd_cost: 0 });
+  });
+});
+
+describe("P1-19 — !help", () => {
+  test("returns the static help text on a single page (~92 chars)", async () => {
+    const res = await postIpc(envelope("!help"));
+    expect(res.status).toBe(200);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("!ping");
+    expect(messages[0]).toContain("!post");
+    expect(messages[0]).toContain("!mail");
+    expect(messages[0]).toContain("!todo");
+    expect(messages[0]).toContain("!cost");
+    expect(messages[0].length).toBeLessThanOrEqual(160);
+  });
+
+  test("does not record a ledger transaction (free informational command)", async () => {
+    await postIpc(envelope("!help"));
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(0);
+  });
+});
+
+describe("P1-19 — !cost", () => {
+  test("empty ledger → '0 req · 0.0k tok · $0.00 (since YYYY-MM-01)'", async () => {
+    const res = await postIpc(envelope("!cost"));
+    expect(res.status).toBe(200);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toHaveLength(1);
+    const expectedDate = new Date().toISOString().slice(0, 7) + "-01";
+    expect(messages[0]).toBe(`0 req · 0.0k tok · $0.00 (since ${expectedDate})`);
+    expect(messages[0].length).toBeLessThanOrEqual(80);
+  });
+
+  test("after recorded transactions → reflects requests + tokens + cost", async () => {
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 1500, completion_tokens: 500 },
+      env: makeTestEnv({
+        ...env,
+        LLM_INPUT_COST_PER_1K: "0.10",
+        LLM_OUTPUT_COST_PER_1K: "0.30",
+      }),
+    });
+    // Same env shape used by the request handler — write the same KV namespace.
+    Object.assign(env, {
+      LLM_INPUT_COST_PER_1K: "0.10",
+      LLM_OUTPUT_COST_PER_1K: "0.30",
+    });
+
+    const res = await postIpc(envelope("!cost"));
+    expect(res.status).toBe(200);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    // 2000 tokens total → "2.0k tok"; 1500*0.0001 + 500*0.0003 = 0.15 + 0.15 = $0.30
+    expect(messages[0]).toMatch(/^1 req · 2\.0k tok · \$0\.30 \(since \d{4}-\d{2}-01\)$/);
+  });
+
+  test("does not record a ledger transaction itself (would skew its own output)", async () => {
+    const before = await monthlyTotals(env);
+    await postIpc(envelope("!cost"));
+    const after = await monthlyTotals(env);
+    expect(after.requests).toBe(before.requests);
+  });
+});
+
+describe("P1-19 — APPEND_COST_SUFFIX integration", () => {
+  test("when enabled, !ping reply ends with ` · $X.XX`", async () => {
+    env.APPEND_COST_SUFFIX = "true";
+    // Seed the ledger with a non-zero cost so the suffix is visible.
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 1000, completion_tokens: 0 },
+      env: makeTestEnv({ ...env, LLM_INPUT_COST_PER_1K: "0.07" }),
+    });
+    Object.assign(env, { LLM_INPUT_COST_PER_1K: "0.07" });
+
+    await postIpc(envelope("!ping"));
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toContain("pong");
+    expect(messages[0]).toMatch(/· \$\d+\.\d{2}$/);
+  });
+
+  test("when disabled (default), no suffix is appended", async () => {
+    await postIpc(envelope("!ping"));
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toBe("pong");
+  });
+});
+
+describe("P1-19 — unknown command path", () => {
+  test("unparseable text → 'Unknown command. Try !help' delivered, no ledger entry", async () => {
+    const res = await postIpc(envelope("not a command"));
+    expect(res.status).toBe(200);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Unknown command. Try !help"]);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace canned orchestrator strings with real implementations for the three non-AI commands: `!ping` records a 0-cost ledger transaction and propagates GPS, `!help` returns the existing static help text, `!cost` reads `monthlyTotals(env)` and formats `"<requests> req · <Xk> tok · $<cost> (since <YYYY-MM-01>)"`.
- Wire `buildReply` (P1-15) into the request path: orchestrator's `CommandResult { body, lat?, lon? }` feeds directly into `buildReply` which produces the 1-or-2-page array `sendReply` consumes. Cost suffix is opt-in via `APPEND_COST_SUFFIX` (skips the ledger round-trip when disabled).
- `trySendReplyWithCheckpoint` now takes a pre-built page array. Error replies and "Unknown command" path also flow through `buildReply` for consistent shaping.

Closes #55. Soft-completes the dependency chain P1-01 → P1-02 → P1-11 → P1-15 → P1-19.

## Ledger behavior

| Command | Records? | Reason |
|---|---|---|
| `!ping` | yes (0 cost) | Counts as a "request" so users can see total interactions in `!cost` |
| `!help` | no | Free informational lookup |
| `!cost` | no | Would skew its own output |

The AI commands (`!post`/`!mail`/`!todo`) record via their P1-16/17/18 pipelines later.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 140 passing (129 baseline + 11 new)
- [ ] CI green on PR
- [ ] **Manual staging test** (acceptance #5 — gated on #56 P1-20 journal repo bootstrap and `wrangler secret put LLM_API_KEY` for staging): send `!ping` from the device and confirm `pong` arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)