### PR TITLE
feat(narrative): real OpenRouter chatCompletion + JSON-mode narrative module (P1-05)

### DIFF
--- a/src/adapters/ai/openrouter.ts
+++ b/src/adapters/ai/openrouter.ts
@@ -1,5 +1,7 @@
 import type { Env } from "../../env.js";
 
+const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
+
 /**
  * Raw chat-completion request shape (OpenAI-compatible — OpenRouter accepts
  * the same JSON envelope and forwards to whichever model `LLM_MODEL` selects).
@@ -29,18 +31,117 @@ export interface ChatCompletionResponse {
 }
 
 /**
- * Thin HTTP wrapper around the OpenRouter chat-completions endpoint.
- *
- * Reads `env.LLM_BASE_URL` (default `https://openrouter.ai/api/v1`) and
- * `env.LLM_API_KEY`. If `env.LLM_PROVIDER_HEADERS_JSON` parses as an object,
- * its keys are merged in — used for OpenRouter's `HTTP-Referer` + `X-Title`
- * analytics headers.
- *
- * Stub in Phase 0 — real implementation in P1-05.
+ * Typed error from the LLM endpoint. `status` is the HTTP status (0 for
+ * network / non-HTTP errors).
  */
-export async function chatCompletion(
-  _req: ChatCompletionRequest,
-  _env: Env,
-): Promise<ChatCompletionResponse> {
-  throw new Error("chatCompletion: not implemented in Phase 0 — P1-05 target");
+export class LLMError extends Error {
+  public readonly status: number;
+
+  constructor(opts: { status: number; message: string }) {
+    super(opts.message);
+    this.name = "LLMError";
+    this.status = opts.status;
+  }
+}
+
+export interface ChatCompletionArgs {
+  req: ChatCompletionRequest;
+  env: Env;
+  /** Injectable sleep helper for tests; defaults to setTimeout. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+/**
+ * HTTPS POST to `${LLM_BASE_URL}/chat/completions` with bearer auth.
+ *
+ * Merges `LLM_PROVIDER_HEADERS_JSON` (if set) onto the request — OpenRouter
+ * uses `HTTP-Referer` + `X-Title` for analytics. 4xx surfaces immediately
+ * (caller's prompt or auth is broken; retry won't help). 5xx + network errors
+ * retry at 1s/4s/16s (initial + 3 retries = 4 attempts).
+ */
+export async function chatCompletion(args: ChatCompletionArgs): Promise<ChatCompletionResponse> {
+  const { req, env } = args;
+  const delay = args.delay ?? defaultDelay;
+  const url = `${stripTrailingSlash(env.LLM_BASE_URL)}/chat/completions`;
+  const headers = buildHeaders(env);
+  const init: RequestInit = {
+    method: "POST",
+    headers,
+    body: JSON.stringify(req),
+  };
+
+  let lastErr: LLMError | undefined;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await delay(RETRY_DELAYS_MS[attempt - 1]);
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(url, init);
+    } catch (e) {
+      lastErr = new LLMError({
+        status: 0,
+        message: `network error: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      continue;
+    }
+
+    if (res.ok) {
+      const data = (await res.json()) as ChatCompletionResponse;
+      return data;
+    }
+
+    const message = await readErrorMessage(res);
+    const err = new LLMError({
+      status: res.status,
+      message: `HTTP ${res.status}: ${message}`,
+    });
+
+    // 4xx is a caller bug (bad model name, bad schema, auth failure) — surface
+    // immediately. 5xx and network errors are transient → retry.
+    if (res.status >= 400 && res.status < 500) {
+      throw err;
+    }
+    lastErr = err;
+  }
+
+  throw lastErr ?? new LLMError({ status: 0, message: "chatCompletion failed without a captured error" });
+}
+
+function buildHeaders(env: Env): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${env.LLM_API_KEY}`,
+    "Content-Type": "application/json",
+  };
+  if (env.LLM_PROVIDER_HEADERS_JSON.length > 0) {
+    try {
+      const extra = JSON.parse(env.LLM_PROVIDER_HEADERS_JSON) as Record<string, unknown>;
+      for (const [k, v] of Object.entries(extra)) {
+        if (typeof v === "string") headers[k] = v;
+      }
+    } catch {
+      // Ignore malformed JSON — env validation accepts the empty string but
+      // not all callers will keep it well-formed; better to send the request
+      // without analytics headers than to fail.
+    }
+  }
+  return headers;
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: { message?: string }; message?: string };
+    return body.error?.message ?? body.message ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/core/narrative.ts
+++ b/src/core/narrative.ts
@@ -1,0 +1,156 @@
+import { z } from "zod";
+import type { Env } from "../env.js";
+import { chatCompletion } from "../adapters/ai/openrouter.js";
+
+/**
+ * Narrative module — composes a `!post` event into a structured blog post via
+ * the configured LLM (P1-04: model + base URL come from env, defaulting to
+ * `openai/gpt-5-mini` on OpenRouter).
+ *
+ * The orchestrator (P1-16) calls `generateNarrative(input)` once per `!post`,
+ * gets back `{ title, haiku, body, usage }`, and:
+ *   - feeds `title` + a short summary into the device reply (≤ 160 chars);
+ *   - feeds the full `body` (+ frontmatter using title/haiku) into the journal
+ *     publish (P1-08).
+ *
+ * Token usage from the OpenRouter response is propagated as-is — we never use
+ * character-count proxies (drift over time, undercounts on multi-byte text).
+ */
+export interface NarrativeInput {
+  /** The user's note text from `!post <note>`. */
+  note: string;
+  lat?: number;
+  lon?: number;
+  /** Reverse-geocoded place name (P1-09). Optional — omitted prompt when absent. */
+  placeName?: string;
+  /** Weather summary (P1-10). Optional — omitted prompt when absent. */
+  weather?: string;
+  env: Env;
+}
+
+export interface NarrativeOutput {
+  title: string;
+  haiku: string;
+  body: string;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+  };
+}
+
+/** JSON-schema enforced by the LLM provider's structured-output mode. */
+const NARRATIVE_SCHEMA = {
+  name: "narrative",
+  strict: true,
+  schema: {
+    type: "object",
+    properties: {
+      title: { type: "string", maxLength: 60 },
+      haiku: { type: "string", maxLength: 80 },
+      body: { type: "string", maxLength: 500 },
+    },
+    required: ["title", "haiku", "body"],
+    additionalProperties: false,
+  },
+} as const;
+
+const NarrativeContentSchema = z.object({
+  title: z.string().min(1).max(60),
+  haiku: z.string().min(1).max(80),
+  body: z.string().min(1).max(500),
+});
+
+/**
+ * The system prompt drives tone and the hard caps. The schema enforces the
+ * length caps server-side; the prompt is what makes the model actually *try*
+ * to stay within them and to match the user's voice.
+ */
+const SYSTEM_PROMPT = [
+  "You write short field-journal entries from a backcountry traveller's brief notes.",
+  "Always return valid JSON matching the schema. No prose outside the JSON.",
+  "Constraints:",
+  '- "title": ≤ 60 characters, evocative, no clickbait, no emoji.',
+  '- "haiku": exactly three lines separated by newlines, in 5/7/5 syllables, ≤ 80 characters total. Plain English. No formatting marks.',
+  '- "body": ≤ 500 characters. Match the voice and tone of the input note. First-person if the note is first-person; observational if observational. Do not invent specifics not implied by the note, place, or weather context.',
+].join("\n");
+
+export class NarrativeError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "NarrativeError";
+  }
+}
+
+export async function generateNarrative(input: NarrativeInput): Promise<NarrativeOutput> {
+  const userPrompt = buildUserPrompt(input);
+  const model = input.env.LLM_MODEL || "openai/gpt-5-mini";
+
+  const response = await chatCompletion({
+    req: {
+      model,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userPrompt },
+      ],
+      response_format: { type: "json_schema", json_schema: NARRATIVE_SCHEMA },
+      temperature: 0.7,
+      max_tokens: 600,
+    },
+    env: input.env,
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (typeof content !== "string" || content.length === 0) {
+    throw new NarrativeError("LLM returned no content");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (e) {
+    throw new NarrativeError(`LLM returned non-JSON content: ${content.slice(0, 120)}`, {
+      cause: e,
+    });
+  }
+
+  const validated = NarrativeContentSchema.safeParse(parsed);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+    throw new NarrativeError(`LLM output failed schema: ${issues}`);
+  }
+
+  return {
+    title: validated.data.title,
+    haiku: validated.data.haiku,
+    body: validated.data.body,
+    usage: {
+      prompt_tokens: response.usage.prompt_tokens,
+      completion_tokens: response.usage.completion_tokens,
+    },
+  };
+}
+
+/**
+ * Compose the user-facing prompt. When lat/lon/placeName/weather are absent
+ * (no GPS fix or geocode/weather lookup failed upstream), those lines are
+ * omitted entirely — no "(unknown)" or "(0,0)" placeholders that would steer
+ * the model toward synthesising location-specific detail.
+ */
+function buildUserPrompt(input: NarrativeInput): string {
+  const lines: string[] = [];
+  lines.push(`Note: ${input.note}`);
+
+  if (
+    input.placeName !== undefined &&
+    input.lat !== undefined &&
+    input.lon !== undefined
+  ) {
+    lines.push(`Location: ${input.placeName} (${input.lat.toFixed(4)}, ${input.lon.toFixed(4)})`);
+  }
+
+  if (input.weather !== undefined) {
+    lines.push(`Weather: ${input.weather}`);
+  }
+
+  return lines.join("\n");
+}

--- a/tests/narrative.test.ts
+++ b/tests/narrative.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { generateNarrative, NarrativeError } from "../src/core/narrative.js";
+import type { Env } from "../src/env.js";
+import { makeTestEnv } from "./helpers/env.js";
+
+let env: Env;
+// Workers' fetch overload signature confuses vitest's MockInstance generic;
+// type as MockedFunction of the basic global fetch shape.
+let fetchSpy: ReturnType<typeof vi.fn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+const originalFetch = globalThis.fetch;
+
+const NATALIE_NOTE =
+  "Lake Sabrina basin glowing pink at sunset, alpenglow on the granite walls. Cold wind off the cirque.";
+
+function jsonResponse(content: object | string, opts: Partial<{ status: number; usage: object }> = {}) {
+  const body = {
+    id: "chatcmpl-test",
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: typeof content === "string" ? content : JSON.stringify(content),
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: opts.usage ?? { prompt_tokens: 240, completion_tokens: 180, total_tokens: 420 },
+  };
+  return new Response(JSON.stringify(body), {
+    status: opts.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchSpy = vi.fn();
+  globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("generateNarrative — happy path", () => {
+  test("returns parsed { title, haiku, body, usage } from a well-formed JSON response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({
+        title: "Alpenglow at Lake Sabrina",
+        haiku: "Granite walls glow pink\nWind drops off the cirque\nCold breath turns mist",
+        body: "Pink light bleeds across the basin walls as the day dies behind the crest.",
+      }),
+    );
+
+    const out = await generateNarrative({ note: NATALIE_NOTE, env });
+
+    expect(out.title).toBe("Alpenglow at Lake Sabrina");
+    expect(out.haiku.split("\n")).toHaveLength(3);
+    expect(out.body).toContain("Pink light");
+    expect(out.usage).toEqual({ prompt_tokens: 240, completion_tokens: 180 });
+  });
+
+  test("posts to LLM_BASE_URL/chat/completions with bearer auth", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "x", env });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect((init as RequestInit).method).toBe("POST");
+
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Bearer ${env.LLM_API_KEY}`);
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  test("uses LLM_MODEL from env (default: openai/gpt-5-mini)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "x", env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { model: string };
+    expect(body.model).toBe("openai/gpt-5-mini");
+  });
+
+  test("requests json_schema structured output", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "x", env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      response_format: { type: string; json_schema: { name: string } };
+    };
+    expect(body.response_format.type).toBe("json_schema");
+    expect(body.response_format.json_schema.name).toBe("narrative");
+  });
+});
+
+describe("generateNarrative — prompt composition", () => {
+  test("with lat/lon/placeName/weather → prompt includes Location + Weather lines", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({
+      note: NATALIE_NOTE,
+      lat: 37.1682,
+      lon: -118.5891,
+      placeName: "Lake Sabrina, Inyo County, CA",
+      weather: "Clear · 8°C · wind 12 km/h W",
+      env,
+    });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = body.messages.find((m) => m.role === "user")?.content ?? "";
+    expect(userMsg).toContain(`Note: ${NATALIE_NOTE}`);
+    expect(userMsg).toContain("Location: Lake Sabrina, Inyo County, CA (37.1682, -118.5891)");
+    expect(userMsg).toContain("Weather: Clear · 8°C · wind 12 km/h W");
+  });
+
+  test("without GPS → prompt OMITS Location line entirely (no '(0, 0)' placeholder)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: NATALIE_NOTE, env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = body.messages.find((m) => m.role === "user")?.content ?? "";
+    expect(userMsg).toContain(`Note: ${NATALIE_NOTE}`);
+    expect(userMsg).not.toContain("Location:");
+    expect(userMsg).not.toContain("0, 0");
+    expect(userMsg).not.toContain("(unknown)");
+  });
+
+  test("placeName missing but lat/lon present → still omits Location (need all three)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "x", lat: 37, lon: -118, env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = body.messages.find((m) => m.role === "user")?.content ?? "";
+    expect(userMsg).not.toContain("Location:");
+  });
+});
+
+describe("generateNarrative — error paths", () => {
+  test("malformed JSON in choices[0].message.content → NarrativeError", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse("Here's your post: {bogus"));
+
+    await expect(generateNarrative({ note: "x", env })).rejects.toBeInstanceOf(NarrativeError);
+  });
+
+  test("schema-violating JSON (missing field) → NarrativeError listing the issue", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", body: "B" }), // missing haiku
+    );
+
+    await expect(generateNarrative({ note: "x", env })).rejects.toThrow(/haiku/);
+  });
+
+  test("title too long → NarrativeError", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "x".repeat(61), haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await expect(generateNarrative({ note: "x", env })).rejects.toBeInstanceOf(NarrativeError);
+  });
+
+  test("empty content string → NarrativeError", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(""));
+    await expect(generateNarrative({ note: "x", env })).rejects.toThrow(/no content/);
+  });
+
+  test("4xx response surfaces immediately (no retry)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: "invalid api key" } }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(generateNarrative({ note: "x", env })).rejects.toThrow(/HTTP 401/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("chatCompletion — retry behavior (via narrative)", () => {
+  test("5xx then 200 → retries once, returns success", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response("internal error", { status: 503 }))
+      .mockResolvedValueOnce(
+        jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+      );
+
+    // Inject zero-delay so the test doesn't actually wait 1s.
+    // Wire through the env's ai layer is not exposed; we rely on the global
+    // fetch mock and accept the test sleep is 1s. Mark slow.
+    const out = await generateNarrative({ note: "x", env });
+    expect(out.title).toBe("T");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  }, 10000);
+
+  test("network error then 200 → retries", async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(
+        jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+      );
+
+    const out = await generateNarrative({ note: "x", env });
+    expect(out.title).toBe("T");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  }, 10000);
+});
+
+describe("LLM_PROVIDER_HEADERS_JSON — analytics passthrough", () => {
+  test("merges parsed headers when env var is non-empty JSON", async () => {
+    env.LLM_PROVIDER_HEADERS_JSON = JSON.stringify({
+      "HTTP-Referer": "https://trailscribe.workers.dev",
+      "X-Title": "TrailScribe",
+    });
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "x", env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["HTTP-Referer"]).toBe("https://trailscribe.workers.dev");
+    expect(headers["X-Title"]).toBe("TrailScribe");
+  });
+
+  test("malformed JSON in env var is silently ignored (no throw)", async () => {
+    env.LLM_PROVIDER_HEADERS_JSON = "{not valid json";
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    const out = await generateNarrative({ note: "x", env });
+    expect(out.title).toBe("T");
+  });
+});


### PR DESCRIPTION
## Summary

- **`src/adapters/ai/openrouter.ts`** — replace the Phase 0 stub with a real HTTPS POST. Bearer auth via `LLM_API_KEY`. `LLM_PROVIDER_HEADERS_JSON` is parsed (when non-empty) and merged in for OpenRouter's `HTTP-Referer` + `X-Title` analytics. 4xx surfaces immediately; 5xx + network errors retry at 1s/4s/16s (4 attempts total). Typed `LLMError` with status code.
- **`src/core/narrative.ts`** — new module. `generateNarrative(input)` takes the `!post` note + optional `placeName` / `lat` / `lon` / `weather` and returns `{ title, haiku, body, usage }`. Uses `response_format: { type: "json_schema", json_schema: ... }` so the provider rejects non-conforming output server-side; `zod` re-validates on parse for defense in depth.
- **Prompt composition** omits `Location:` / `Weather:` lines entirely when their inputs are absent — no `(0, 0)` or `(unknown)` placeholders that would steer the model toward synthesising location-specific detail it shouldn't have.
- **Token usage** is taken straight from `response.usage.{prompt_tokens, completion_tokens}` — never char-count proxies, which drift on multi-byte text.

Closes #41.

## Caps enforced two ways

| Field | Cap | Enforced by |
|---|---|---|
| `title` | 60 chars | `json_schema` server-side + zod client-side |
| `haiku` | 80 chars | same |
| `body` | 500 chars | same |

The schema rejection happens before the response leaves the model — most cost-efficient way to catch overruns without re-prompting.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 156 passing (140 baseline + 16 new)
- [ ] CI green on PR
- [ ] **First real call** in P1-16 PR (`!post` pipeline) — gated on `wrangler secret put LLM_API_KEY` for staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)