### PR TITLE
feat(publish): GitHub Pages markdown commit adapter (P1-08)

### DIFF
--- a/src/adapters/publish/github-pages.ts
+++ b/src/adapters/publish/github-pages.ts
@@ -1,21 +1,281 @@
 import type { Env } from "../../env.js";
 
+const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
+const MAX_SLUG_COLLISION_ATTEMPTS = 10;
+
 export interface PublishPostArgs {
   title: string;
+  haiku: string;
   body: string;
-  frontmatter?: Record<string, unknown>;
+  lat?: number;
+  lon?: number;
+  placeName?: string;
+  weather?: string;
   env: Env;
+  /** Injectable for tests; defaults to setTimeout. */
+  delay?: (ms: number) => Promise<void>;
+  /** Injectable for tests; defaults to `new Date()`. */
+  now?: () => Date;
 }
 
 export interface PublishPostResult {
   url: string;
+  path: string;
+  sha: string;
+}
+
+export class PublishError extends Error {
+  public readonly status: number;
+  constructor(opts: { status: number; message: string }) {
+    super(opts.message);
+    this.name = "PublishError";
+    this.status = opts.status;
+  }
+}
+
+interface ContentsApiPutResponse {
+  content: { sha: string; path: string; html_url: string };
+  commit: { sha: string };
+}
+
+interface ContentsApiErrorBody {
+  message?: string;
 }
 
 /**
- * Publish a journal entry by committing a markdown file to the journal repo
- * via GitHub Contents API.
- * Stub in Phase 0 — real implementation in Phase 1.
+ * Commit one markdown file per `!post` to the dedicated journal repo via the
+ * GitHub Contents API. Public URL is derived from `JOURNAL_URL_TEMPLATE`
+ * (P1-04) so reply links survive a Jekyll/Hugo theme swap.
+ *
+ * Slug is derived from the narrative title (lowercase ASCII alphanumerics
+ * plus hyphens, ≤ 50 chars). On the rare same-minute collision we GET the
+ * candidate path; on 200 we increment a `-2`, `-3`, … suffix until 404.
+ *
+ * Auth: fine-grained PAT in `GITHUB_JOURNAL_TOKEN` scoped to exactly the
+ * journal repo (`contents:write`). 4xx surfaces immediately (auth/perm bug
+ * — retrying won't help). 5xx retries 1 s / 4 s / 16 s.
+ *
+ * Frontmatter shape (Jekyll/Hugo compatible). `location:` and `weather:`
+ * keys are omitted when their inputs are absent — no `(0, 0)` placeholders.
  */
-export async function publishPost(_args: PublishPostArgs): Promise<PublishPostResult> {
-  throw new Error("publishPost: not implemented in Phase 0 — Phase 1 target");
+export async function publishPost(args: PublishPostArgs): Promise<PublishPostResult> {
+  const { title, haiku, body, lat, lon, placeName, weather, env } = args;
+  const now = (args.now ?? (() => new Date()))();
+  const delay = args.delay ?? defaultDelay;
+
+  const yyyy = String(now.getUTCFullYear());
+  const mm = pad2(now.getUTCMonth() + 1);
+  const dd = pad2(now.getUTCDate());
+
+  const baseSlug = slugify(title, now);
+  const { path, slug: finalSlug } = await findFreePath(env, args.env.JOURNAL_POST_PATH_TEMPLATE, {
+    yyyy,
+    mm,
+    dd,
+    baseSlug,
+  });
+
+  const markdown = renderMarkdown({
+    title,
+    haiku,
+    body,
+    date: now.toISOString(),
+    lat,
+    lon,
+    placeName,
+    weather,
+  });
+
+  const putResp = await putContents(env, path, markdown, title, delay);
+
+  const url = renderUrl(env.JOURNAL_URL_TEMPLATE, { yyyy, mm, dd, slug: finalSlug });
+  return { url, path, sha: putResp.commit.sha };
+}
+
+/**
+ * Public for tests — slug derivation. Returns at most 50 lowercase
+ * alphanumeric/hyphen chars; fallback `untitled-HHMMSS` when title strips
+ * empty.
+ */
+export function slugify(title: string, fallbackNow: Date): string {
+  const stripped = title
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip combining marks
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  let slug = stripped;
+  if (slug.length > 50) {
+    slug = slug.slice(0, 50).replace(/-+$/, "");
+  }
+  if (slug.length === 0) {
+    slug = `untitled-${pad2(fallbackNow.getUTCHours())}${pad2(fallbackNow.getUTCMinutes())}${pad2(fallbackNow.getUTCSeconds())}`;
+  }
+  return slug;
+}
+
+async function findFreePath(
+  env: Env,
+  template: string,
+  parts: { yyyy: string; mm: string; dd: string; baseSlug: string },
+): Promise<{ path: string; slug: string }> {
+  for (let i = 0; i < MAX_SLUG_COLLISION_ATTEMPTS; i += 1) {
+    const slug = i === 0 ? parts.baseSlug : `${parts.baseSlug}-${i + 1}`;
+    const path = template
+      .replaceAll("{yyyy}", parts.yyyy)
+      .replaceAll("{mm}", parts.mm)
+      .replaceAll("{dd}", parts.dd)
+      .replaceAll("{slug}", slug);
+
+    const exists = await contentsExists(env, path);
+    if (!exists) return { path, slug };
+  }
+  throw new PublishError({
+    status: 0,
+    message: `slug collision: tried ${MAX_SLUG_COLLISION_ATTEMPTS} variants of "${parts.baseSlug}"`,
+  });
+}
+
+async function contentsExists(env: Env, path: string): Promise<boolean> {
+  const url = `https://api.github.com/repos/${env.GITHUB_JOURNAL_REPO}/contents/${encodePath(path)}?ref=${env.GITHUB_JOURNAL_BRANCH}`;
+  const res = await fetch(url, { method: "GET", headers: githubHeaders(env) });
+  if (res.status === 200) return true;
+  if (res.status === 404) return false;
+  // Auth or other error — surface so caller sees real problem rather than
+  // looping into a slug-collision dance.
+  const message = await readErrorMessage(res);
+  throw new PublishError({ status: res.status, message: `GET contents: ${message}` });
+}
+
+async function putContents(
+  env: Env,
+  path: string,
+  markdown: string,
+  title: string,
+  delay: (ms: number) => Promise<void>,
+): Promise<ContentsApiPutResponse> {
+  const url = `https://api.github.com/repos/${env.GITHUB_JOURNAL_REPO}/contents/${encodePath(path)}`;
+  const init: RequestInit = {
+    method: "PUT",
+    headers: githubHeaders(env),
+    body: JSON.stringify({
+      message: `trailscribe: ${title}`,
+      content: base64Utf8(markdown),
+      branch: env.GITHUB_JOURNAL_BRANCH,
+    }),
+  };
+
+  let lastErr: PublishError | undefined;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) await delay(RETRY_DELAYS_MS[attempt - 1]);
+
+    let res: Response;
+    try {
+      res = await fetch(url, init);
+    } catch (e) {
+      lastErr = new PublishError({
+        status: 0,
+        message: `network error: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      continue;
+    }
+
+    if (res.ok) {
+      return (await res.json()) as ContentsApiPutResponse;
+    }
+
+    const message = await readErrorMessage(res);
+    const err = new PublishError({ status: res.status, message: `PUT contents: ${message}` });
+
+    if (res.status >= 400 && res.status < 500) throw err;
+    lastErr = err;
+  }
+
+  throw lastErr ?? new PublishError({ status: 0, message: "publish failed without a captured error" });
+}
+
+function githubHeaders(env: Env): Record<string, string> {
+  return {
+    Authorization: `Bearer ${env.GITHUB_JOURNAL_TOKEN}`,
+    "User-Agent": "trailscribe",
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "Content-Type": "application/json",
+  };
+}
+
+interface RenderArgs {
+  title: string;
+  haiku: string;
+  body: string;
+  date: string;
+  lat?: number;
+  lon?: number;
+  placeName?: string;
+  weather?: string;
+}
+
+function renderMarkdown(a: RenderArgs): string {
+  const lines: string[] = ["---"];
+  lines.push(`title: ${quoteYaml(a.title)}`);
+  lines.push(`date: ${a.date}`);
+  if (a.lat !== undefined && a.lon !== undefined) {
+    const place = a.placeName !== undefined ? `, place: ${quoteYaml(a.placeName)}` : "";
+    lines.push(`location: { lat: ${a.lat}, lon: ${a.lon}${place} }`);
+  }
+  if (a.weather !== undefined) {
+    lines.push(`weather: ${quoteYaml(a.weather)}`);
+  }
+  lines.push("tags: [trailscribe]");
+  lines.push("---");
+  lines.push(a.haiku);
+  lines.push("");
+  lines.push(a.body);
+  return lines.join("\n");
+}
+
+function renderUrl(template: string, parts: { yyyy: string; mm: string; dd: string; slug: string }): string {
+  return template
+    .replaceAll("{yyyy}", parts.yyyy)
+    .replaceAll("{mm}", parts.mm)
+    .replaceAll("{dd}", parts.dd)
+    .replaceAll("{slug}", parts.slug);
+}
+
+function quoteYaml(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Encode each path segment, leaving slashes intact. */
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+/** UTF-8 → base64 (Workers' btoa only accepts Latin-1; need explicit byte path). */
+function base64Utf8(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as ContentsApiErrorBody;
+    return body.message ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/github-pages.test.ts
+++ b/tests/github-pages.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  publishPost,
+  PublishError,
+  slugify,
+} from "../src/adapters/publish/github-pages.js";
+import type { Env } from "../src/env.js";
+import { makeTestEnv } from "./helpers/env.js";
+
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+const NOW = new Date("2026-04-25T17:30:00Z");
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Decode a base64 payload as UTF-8 (atob returns binary-as-Latin-1). */
+function decodeUtf8(b64: string): string {
+  const bin = atob(b64);
+  const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+beforeEach(() => {
+  env = makeTestEnv({
+    GITHUB_JOURNAL_REPO: "brockamer/trailscribe-journal",
+    GITHUB_JOURNAL_BRANCH: "main",
+    GITHUB_JOURNAL_TOKEN: "ghp_test_token_xyz123",
+    JOURNAL_POST_PATH_TEMPLATE: "content/posts/{yyyy}-{mm}-{dd}-{slug}.md",
+    JOURNAL_URL_TEMPLATE: "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html",
+  });
+  fetchSpy = vi.fn();
+  globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("slugify — title → URL slug", () => {
+  test("simple ASCII title → lowercase hyphenated", () => {
+    expect(slugify("Alpenglow at Lake Sabrina", NOW)).toBe("alpenglow-at-lake-sabrina");
+  });
+
+  test("strips non-ASCII (combining accents removed via NFKD)", () => {
+    expect(slugify("Café Crème", NOW)).toBe("cafe-creme");
+  });
+
+  test("collapses runs of non-alphanumerics into single hyphen", () => {
+    expect(slugify("hello!!! world??", NOW)).toBe("hello-world");
+  });
+
+  test("trims leading/trailing hyphens", () => {
+    expect(slugify("--foo bar--", NOW)).toBe("foo-bar");
+  });
+
+  test("truncates at 50 chars and trims trailing hyphen", () => {
+    const out = slugify("x".repeat(80), NOW);
+    expect(out.length).toBeLessThanOrEqual(50);
+  });
+
+  test("empty after stripping → untitled-HHMMSS fallback", () => {
+    expect(slugify("!!!", NOW)).toBe("untitled-173000");
+    expect(slugify("", NOW)).toBe("untitled-173000");
+    // CJK strips to nothing under our ASCII filter.
+    expect(slugify("写真", NOW)).toBe("untitled-173000");
+  });
+});
+
+describe("publishPost — happy path", () => {
+  test("commits markdown with frontmatter; returns url + path + sha", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 })) // GET path: free
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "content/posts/2026-04-25-test.md", html_url: "x" },
+          commit: { sha: "commit-sha-abc123" },
+        }),
+      );
+
+    const result = await publishPost({
+      title: "Test Title",
+      haiku: "First line\nSecond line\nThird line",
+      body: "Body text.",
+      env,
+      now: () => NOW,
+    });
+
+    expect(result.url).toBe(
+      "https://brockamer.github.io/trailscribe-journal/2026/04/25/test-title.html",
+    );
+    expect(result.path).toBe("content/posts/2026-04-25-test-title.md");
+    expect(result.sha).toBe("commit-sha-abc123");
+  });
+
+  test("PUT request carries auth, user-agent, and api-version headers", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "p", html_url: "x" },
+          commit: { sha: "csh" },
+        }),
+      );
+
+    await publishPost({
+      title: "Test",
+      haiku: "a\nb\nc",
+      body: "B",
+      env,
+      now: () => NOW,
+    });
+
+    const putCall = fetchSpy.mock.calls[1];
+    const init = putCall[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Bearer ${env.GITHUB_JOURNAL_TOKEN}`);
+    expect(headers["User-Agent"]).toBe("trailscribe");
+    expect(headers["Accept"]).toBe("application/vnd.github+json");
+    expect(headers["X-GitHub-Api-Version"]).toBe("2022-11-28");
+    expect(init.method).toBe("PUT");
+  });
+
+  test("PUT body is base64'd markdown with frontmatter and branch field", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "p", html_url: "x" },
+          commit: { sha: "csh" },
+        }),
+      );
+
+    await publishPost({
+      title: "Lake Sabrina",
+      haiku: "Granite glow\nCold cirque wind\nDay turns",
+      body: "Pink light bleeds.",
+      lat: 37.1682,
+      lon: -118.5891,
+      placeName: "Lake Sabrina",
+      weather: "Clear · 8C",
+      env,
+      now: () => NOW,
+    });
+
+    const putBody = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string) as {
+      message: string;
+      content: string;
+      branch: string;
+    };
+
+    expect(putBody.message).toBe("trailscribe: Lake Sabrina");
+    expect(putBody.branch).toBe("main");
+
+    const decoded = decodeUtf8(putBody.content);
+    expect(decoded).toContain("---");
+    expect(decoded).toContain('title: "Lake Sabrina"');
+    expect(decoded).toContain("date: 2026-04-25T17:30:00.000Z");
+    expect(decoded).toContain("location: { lat: 37.1682, lon: -118.5891, place: \"Lake Sabrina\" }");
+    expect(decoded).toContain('weather: "Clear · 8C"');
+    expect(decoded).toContain("tags: [trailscribe]");
+    expect(decoded).toContain("Granite glow\nCold cirque wind\nDay turns");
+    expect(decoded).toContain("Pink light bleeds.");
+  });
+});
+
+describe("publishPost — frontmatter conditional keys", () => {
+  test("no GPS → location and weather keys OMITTED entirely", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "p", html_url: "x" },
+          commit: { sha: "csh" },
+        }),
+      );
+
+    await publishPost({
+      title: "No GPS Post",
+      haiku: "a\nb\nc",
+      body: "x",
+      env,
+      now: () => NOW,
+    });
+
+    const putBody = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string) as {
+      content: string;
+    };
+    const decoded = decodeUtf8(putBody.content);
+    expect(decoded).not.toContain("location:");
+    expect(decoded).not.toContain("weather:");
+    expect(decoded).not.toContain("(0, 0)");
+    expect(decoded).toContain("tags: [trailscribe]");
+  });
+
+  test("GPS but no placeName → location includes lat/lon, omits place key", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "p", html_url: "x" },
+          commit: { sha: "csh" },
+        }),
+      );
+
+    await publishPost({
+      title: "Coords only",
+      haiku: "a\nb\nc",
+      body: "x",
+      lat: 37,
+      lon: -118,
+      env,
+      now: () => NOW,
+    });
+
+    const putBody = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string) as {
+      content: string;
+    };
+    const decoded = decodeUtf8(putBody.content);
+    expect(decoded).toContain("location: { lat: 37, lon: -118 }");
+    expect(decoded).not.toContain("place:");
+  });
+});
+
+describe("publishPost — slug collision", () => {
+  test("first path 200 (collision) then 404 → slug becomes <base>-2 and PUT goes there", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({})) // first GET: 200 collision
+      .mockResolvedValueOnce(new Response(null, { status: 404 })) // second GET: 404 free
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "p", html_url: "x" },
+          commit: { sha: "csh" },
+        }),
+      );
+
+    const result = await publishPost({
+      title: "Test",
+      haiku: "a\nb\nc",
+      body: "x",
+      env,
+      now: () => NOW,
+    });
+
+    expect(result.path).toBe("content/posts/2026-04-25-test-2.md");
+    expect(result.url).toContain("/2026/04/25/test-2.html");
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("publishPost — error paths", () => {
+  test("401 on PUT surfaces immediately as PublishError; no retry", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ message: "Bad credentials" }, 401));
+
+    await expect(
+      publishPost({ title: "T", haiku: "a\nb\nc", body: "x", env, now: () => NOW }),
+    ).rejects.toBeInstanceOf(PublishError);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // GET + one PUT, no retry
+  });
+
+  test("503 then 200 → retries", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ message: "service unavailable" }, 503))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "blob-sha", path: "p", html_url: "x" },
+          commit: { sha: "csh" },
+        }),
+      );
+
+    const result = await publishPost({
+      title: "T",
+      haiku: "a\nb\nc",
+      body: "x",
+      env,
+      delay: () => Promise.resolve(),
+      now: () => NOW,
+    });
+    expect(result.sha).toBe("csh");
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("GET collision check failing with 401 throws (doesn't loop into infinite collision dance)", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ message: "bad" }, 401));
+
+    await expect(
+      publishPost({ title: "T", haiku: "a\nb\nc", body: "x", env, now: () => NOW }),
+    ).rejects.toBeInstanceOf(PublishError);
+  });
+});
+
+describe("publishPost — URL template substitution", () => {
+  test("substitutes {yyyy}/{mm}/{dd}/{slug} per JOURNAL_URL_TEMPLATE", async () => {
+    env.JOURNAL_URL_TEMPLATE = "https://example.com/blog/{yyyy}/{mm}/{slug}/";
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: { sha: "b", path: "p", html_url: "x" },
+          commit: { sha: "c" },
+        }),
+      );
+
+    const result = await publishPost({
+      title: "Hello World",
+      haiku: "a\nb\nc",
+      body: "x",
+      env,
+      now: () => NOW,
+    });
+
+    expect(result.url).toBe("https://example.com/blog/2026/04/hello-world/");
+  });
+});


### PR DESCRIPTION
## Summary

Replace the Phase 0 stub at `src/adapters/publish/github-pages.ts` with a real GitHub Contents API adapter:

- **`publishPost({ title, haiku, body, lat?, lon?, placeName?, weather?, env })`** → `Promise<{ url, path, sha }>`. Commits one markdown file per `!post` to `GITHUB_JOURNAL_REPO` via `PUT /repos/{owner}/{repo}/contents/{path}`. Auth via fine-grained PAT in `GITHUB_JOURNAL_TOKEN`.
- **Slug derivation**: NFKD normalize → strip combining marks → drop non-ASCII alphanumerics → collapse to hyphens → ≤ 50 chars. Empty (e.g. CJK-only title) → `untitled-HHMMSS` fallback.
- **Same-minute collision**: rare, but handled. GET-then-PUT loop appends `-2`, `-3`, … up to 10 attempts. GET errors that aren't 404 (e.g. 401) surface immediately so we don't infinite-loop on auth.
- **Frontmatter** is Jekyll/Hugo compatible. `location:` and `weather:` keys are **omitted entirely** when their inputs are absent — no `(0, 0)` placeholders that would render misleadingly on the public site.
- **Retry**: 4xx surfaces immediately (auth/perm bug — retrying won't help); 5xx + network errors retry 1s/4s/16s.

Closes #44.

## Soft-blocked by #56

The *first* real commit needs an actual `brockamer/trailscribe-journal` repo + a Jekyll theme + a fine-grained PAT — that's #56 P1-20, brock-action. Impl + Vitest land here independently against `mocked fetch`. Once #56 lands and `JOURNAL_URL_TEMPLATE` is pinned to the theme's actual URL pattern, P1-16 (`!post` pipeline) wires this into the orchestrator.

## UTF-8 footnote

Workers' `btoa` is Latin-1 only — non-ASCII content (the · in "Clear · 8°C") would silently corrupt without the `TextEncoder` round-trip. The implementation does the explicit byte path; the test uses a `TextDecoder`-based helper to verify.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 172 passing (156 baseline + 16 new)
- [ ] CI green on PR
- [ ] **First real commit** in P1-16 PR (`!post` pipeline) gated on #56 + `wrangler secret put GITHUB_JOURNAL_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)