### PR TITLE
feat(commands): !mail and !todo pipelines (P1-17 + P1-18)

### DIFF
--- a/src/core/commands/mail.ts
+++ b/src/core/commands/mail.ts
@@ -1,0 +1,119 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { reverseGeocode } from "../../adapters/location/geocode.js";
+import { currentWeather } from "../../adapters/location/weather.js";
+import { sendEmail, ResendError } from "../../adapters/mail/resend.js";
+import { recordTransaction } from "../ledger.js";
+import { appendEvent } from "../context.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type MailCommand = Extract<ParsedCommand, { type: "mail" }>;
+
+interface HandleMailContext extends OrchestratorContext {
+  idemKey: string;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * `!mail to:_ subj:_ body:_` pipeline (plan P1-17).
+ *
+ * Composes optional geocode/weather → enriched email body → Resend send
+ * (checkpointed) → ledger + context. Reply is `"Sent to <to>"` with map links
+ * appended via buildReply when GPS is present.
+ */
+export async function handleMail(cmd: MailCommand, ctx: HandleMailContext): Promise<CommandResult> {
+  const { env, imei, lat, lon, idemKey } = ctx;
+
+  if (!EMAIL_RE.test(cmd.to)) {
+    return { body: `Bad to: ${cmd.to.slice(0, 60)}` };
+  }
+
+  const hasGps = lat !== undefined && lon !== undefined;
+  let placeName: string | undefined;
+  let weather: string | undefined;
+  if (hasGps) {
+    const [placeR, wxR] = await Promise.allSettled([
+      reverseGeocode(lat, lon, env),
+      currentWeather(lat, lon, env),
+    ]);
+    if (placeR.status === "fulfilled") placeName = placeR.value;
+    if (wxR.status === "fulfilled") weather = wxR.value;
+  }
+
+  const enrichedBody = composeBody(cmd.body, hasGps, placeName, weather, lat, lon);
+
+  try {
+    await withCheckpoint(env, idemKey, "mail", async () => {
+      const result = await sendEmail({
+        to: cmd.to,
+        subject: cmd.subj,
+        body: enrichedBody,
+        env,
+      });
+      return { id: result.id };
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "mail_send_failed", level: "error", imei, to: cmd.to, error: msg });
+    await markFailed(env, idemKey, `mail: ${msg}`);
+    if (err instanceof ResendError) {
+      return { body: `Mail failed: ${msg.slice(0, 80)}` };
+    }
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  try {
+    await recordTransaction({
+      command: "mail",
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "mail_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  try {
+    await appendEvent(
+      imei,
+      {
+        timestamp: Date.now(),
+        lat,
+        lon,
+        command_type: "mail",
+        free_text: `${cmd.to}|${cmd.subj}`,
+      },
+      env,
+    );
+  } catch (err) {
+    log({
+      event: "mail_context_append_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return { body: `Sent to ${cmd.to}`, lat, lon };
+}
+
+function composeBody(
+  userBody: string,
+  hasGps: boolean,
+  placeName: string | undefined,
+  weather: string | undefined,
+  lat: number | undefined,
+  lon: number | undefined,
+): string {
+  const iso = new Date().toISOString();
+  const footer = hasGps
+    ? `\n\n---\nFrom inReach @ ${placeName ?? "unknown"} (${lat},${lon}, ${weather ?? "weather unavailable"}) — sent ${iso}`
+    : `\n\n---\nFrom inReach — sent ${iso}`;
+  return userBody + footer;
+}

--- a/src/core/commands/todo.ts
+++ b/src/core/commands/todo.ts
@@ -1,0 +1,81 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { addTask, TodoistError } from "../../adapters/tasks/todoist.js";
+import { recordTransaction } from "../ledger.js";
+import { appendEvent } from "../context.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type TodoCommand = Extract<ParsedCommand, { type: "todo" }>;
+
+interface HandleTodoContext extends OrchestratorContext {
+  idemKey: string;
+}
+
+/**
+ * `!todo <task>` pipeline (plan P1-18). Composes Todoist create
+ * (checkpointed) → ledger + context → reply with the public Todoist URL.
+ */
+export async function handleTodo(cmd: TodoCommand, ctx: HandleTodoContext): Promise<CommandResult> {
+  const { env, imei, lat, lon, idemKey } = ctx;
+
+  let url: string;
+  try {
+    const result = await withCheckpoint(env, idemKey, "todo", () =>
+      addTask({
+        task: cmd.task,
+        lat,
+        lon,
+        timestamp: Date.now(),
+        env,
+      }),
+    );
+    url = result.url;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "todo_create_failed", level: "error", imei, error: msg });
+    await markFailed(env, idemKey, `todo: ${msg}`);
+    if (err instanceof TodoistError) {
+      return { body: `Todo failed: ${msg.slice(0, 80)}` };
+    }
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  try {
+    await recordTransaction({
+      command: "todo",
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "todo_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  try {
+    await appendEvent(
+      imei,
+      {
+        timestamp: Date.now(),
+        lat,
+        lon,
+        command_type: "todo",
+        free_text: cmd.task,
+      },
+      env,
+    );
+  } catch (err) {
+    log({
+      event: "todo_context_append_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return { body: `Task added · ${url}`, lat, lon };
+}

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2,6 +2,8 @@ import type { ParsedCommand, CommandResult } from "./types.js";
 import type { Env } from "../env.js";
 import { monthlyTotals, recordTransaction, type LedgerSnapshot } from "./ledger.js";
 import { handlePost } from "./commands/post.js";
+import { handleMail } from "./commands/mail.js";
+import { handleTodo } from "./commands/todo.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -47,9 +49,9 @@ export async function orchestrate(
     case "post":
       return handlePost(command, ctx);
     case "mail":
-      return { body: "α: !mail not yet implemented (Phase 1)" };
+      return handleMail(command, ctx);
     case "todo":
-      return { body: "α: !todo not yet implemented (Phase 1)" };
+      return handleTodo(command, ctx);
   }
 }
 

--- a/tests/p1-17-18-mail-todo-pipelines.test.ts
+++ b/tests/p1-17-18-mail-todo-pipelines.test.ts
@@ -1,0 +1,328 @@
+/**
+ * P1-17 + P1-18 — End-to-end integration tests for !mail and !todo pipelines.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+const LAT = 37.1682;
+const LON = -118.5891;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function envelope(freeText: string, opts: { ts?: number; gps?: { lat: number; lon: number } } = {}) {
+  const point = opts.gps
+    ? { latitude: opts.gps.lat, longitude: opts.gps.lon, altitude: 1000, gpsFix: 2 }
+    : { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 };
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point,
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+function makeFetchRouter(
+  routes: Array<{ match: (url: string, init?: RequestInit) => boolean; respond: () => Response | Promise<Response> }>,
+) {
+  return vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const r of routes) {
+      if (r.match(u, init)) return await r.respond();
+    }
+    throw new Error(`unmatched fetch: ${u}`);
+  });
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({ MAPSHARE_BASE: "https://share.garmin.com/MyMap" });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P1-17 !mail — happy path with GPS", () => {
+  test("calls geocode + weather + Resend; reply contains 'Sent to <to>' + map link", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () =>
+          jsonResponse({
+            display_name: "Lake Sabrina, Inyo County, California",
+            address: { locality: "Lake Sabrina", state: "California" },
+          }),
+      },
+      {
+        match: (u) => u.includes("api.open-meteo.com"),
+        respond: () =>
+          jsonResponse({
+            current: { temperature_2m: 46, wind_speed_10m: 8, weather_code: 0 },
+          }),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_abc" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail to:friend@example.com subj:hi body:from the field", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("Sent to friend@example.com");
+    expect(joined).toContain("https://www.google.com/maps");
+
+    // Verify Resend got the enriched body with location footer.
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCall).toBeDefined();
+    const resendBody = JSON.parse((resendCall![1] as RequestInit).body as string) as {
+      from: string;
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(resendBody.text).toContain("from the field");
+    expect(resendBody.text).toContain("From inReach @ Lake Sabrina, California");
+    expect(resendBody.text).toContain("(37.1682,-118.5891");
+  });
+});
+
+describe("P1-17 !mail — no GPS", () => {
+  test("skips geocode + weather; footer omits location; reply omits map link", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_abc" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail to:friend@example.com subj:hi body:hello"));
+
+    const calls = fetchSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(calls.some((u: string) => u.includes("nominatim"))).toBe(false);
+    expect(calls.some((u: string) => u.includes("open-meteo"))).toBe(false);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages.join(" ")).not.toContain("https://www.google.com/maps");
+
+    const resendCall = fetchSpy.mock.calls[0];
+    const resendBody = JSON.parse((resendCall[1] as RequestInit).body as string) as { text: string };
+    expect(resendBody.text).toContain("hello");
+    expect(resendBody.text).toContain("From inReach — sent");
+    expect(resendBody.text).not.toContain("From inReach @");
+  });
+});
+
+describe("P1-17 !mail — bad email address", () => {
+  test("rejects syntactically invalid 'to' before any send", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail to:not-an-email subj:hi body:x"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Bad to:/);
+  });
+});
+
+describe("P1-17 !mail — Resend 4xx", () => {
+  test("400 → 'Mail failed: ...'; markFailed", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ name: "validation_error", message: "bad domain" }, 400),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail to:friend@example.com subj:hi body:x"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Mail failed:/);
+  });
+});
+
+describe("P1-17 !mail — replay safety", () => {
+  test("first run sends; replay does not call Resend again", async () => {
+    let resendCalls = 0;
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => {
+          resendCalls += 1;
+          return jsonResponse({ id: "re_msg" });
+        },
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail to:friend@example.com subj:hi body:x"));
+    expect(resendCalls).toBe(1);
+
+    await postIpc(envelope("!mail to:friend@example.com subj:hi body:x"));
+    // status="completed" short-circuits at app.ts level; Resend not called again.
+    expect(resendCalls).toBe(1);
+  });
+});
+
+describe("P1-18 !todo — happy path", () => {
+  test("creates Todoist task; reply includes task URL", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.todoist.com"),
+        respond: () => jsonResponse({ id: "task-123" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!todo file expense report", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("Task added · https://todoist.com/showTask?id=task-123");
+    expect(joined).toContain("https://www.google.com/maps");
+
+    // Verify the task description carried lat/lon.
+    const todoistCall = fetchSpy.mock.calls[0];
+    const todoistBody = JSON.parse((todoistCall[1] as RequestInit).body as string) as {
+      content: string;
+      description: string;
+    };
+    expect(todoistBody.content).toBe("file expense report");
+    expect(todoistBody.description).toContain("37.1682,-118.5891");
+  });
+
+  test("ledger transaction recorded as 0-cost", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.todoist.com"),
+        respond: () => jsonResponse({ id: "task-xyz" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!todo do thing"));
+
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(1);
+    expect(snap.usd_cost).toBe(0);
+    expect(snap.by_command["todo"]?.requests).toBe(1);
+  });
+});
+
+describe("P1-18 !todo — no GPS", () => {
+  test("description omits coords cleanly when no GPS fix", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.todoist.com"),
+        respond: () => jsonResponse({ id: "task-no-gps" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!todo no fix"));
+
+    const todoistBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as {
+      description: string;
+    };
+    expect(todoistBody.description).not.toContain(",");
+    expect(todoistBody.description).not.toContain("0,0");
+  });
+});
+
+describe("P1-18 !todo — Todoist 4xx", () => {
+  test("400 → 'Todo failed: ...'", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.todoist.com"),
+        respond: () => jsonResponse({ error: "bad token" }, 400),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!todo x"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Todo failed:/);
+  });
+});
+
+describe("P1-18 !todo — replay safety", () => {
+  test("first run creates; replay does not call Todoist again", async () => {
+    let todoistCalls = 0;
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.todoist.com"),
+        respond: () => {
+          todoistCalls += 1;
+          return jsonResponse({ id: "t-1" });
+        },
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!todo replay test"));
+    expect(todoistCalls).toBe(1);
+
+    await postIpc(envelope("!todo replay test"));
+    expect(todoistCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Bundling P1-17 (`!mail`) and P1-18 (`!todo`) into one PR — both pipelines follow the same shape as P1-16 minus narrative + publish, so reviewing them together makes the symmetry obvious.

### `src/core/commands/mail.ts` — handleMail

- Rejects syntactically-invalid `to` addresses up front with `"Bad to: <to>"`.
- Optional geocode + weather (parallel, GPS-gated).
- `withCheckpoint("mail", sendEmail)` — replay-safe.
- Enriched body footer: with GPS includes place + coords + weather + ISO timestamp; without GPS just the timestamp.
- Reply: `"Sent to <to>"` (+ map links via `buildReply` when GPS).
- Resend 4xx → `"Mail failed: <80-char-msg>"`.

### `src/core/commands/todo.ts` — handleTodo

- `withCheckpoint("todo", addTask)` — replay-safe.
- Reply: `"Task added · <todoist-url>"` (+ map links when GPS).
- Todoist 4xx → `"Todo failed: <80-char-msg>"`.

Both record 0-cost ledger transactions and append to the per-IMEI context window. Ledger + context-append failures are warn-logged but don't block the user reply.

Closes #53, closes #54.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 187 passing (177 baseline + 10 new)
- [ ] CI green on PR
- [ ] **Manual staging tests**: one real `!mail` to a held-out recipient confirms delivery; one real `!todo` confirms task creation. Gated on `wrangler secret put RESEND_API_KEY` and `wrangler secret put TODOIST_API_TOKEN` already being in place.

After this lands, all 6 α-MVP commands have real pipelines end-to-end. Phase 1 closeout depends only on the verification trio (#57 P1-21 staging burn-in / #58 P1-22 idempotency replay / #59 P1-23 cost measurement) plus the brock-action #56 P1-20 journal repo bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)