### PR TITLE
docs(replay): manual replay-verification driver + runbook (P1-22)

### DIFF
--- a/docs/replay-verification.md
+++ b/docs/replay-verification.md
@@ -1,0 +1,161 @@
+# P1-22 — Idempotency Replay Verification
+
+Manual procedure to verify that re-delivering the same Garmin webhook payload to staging produces no duplicate side-effects. Closes the PRD success criterion *"0 duplicate side-effects across 10 manual replays."*
+
+## What replay safety means here
+
+Garmin retries an Outbound webhook on this schedule when our 200 is delayed or the response is missing: **2 / 4 / 8 / 16 / 32 / 64 / 128 seconds, then 12-hour pauses for 5 days**. Without idempotency, a slow LLM call or a transient network blip means the user sees their `!post` published twice, gets two emails, or sees two Todoist tasks. The fix is the per-op `withCheckpoint` helper (P1-13) — every side-effecting step writes its result to `TS_IDEMPOTENCY` KV under a sha256 key derived from `imei + timeStamp + messageCode + content_hash`. On replay, completed ops short-circuit.
+
+This doc is the manual verification of that mechanism end-to-end against a real staging deploy.
+
+## Prerequisites (one-time)
+
+1. **Phase 1 deployed to staging.** `pnpm deploy:staging` after PR #81 is merged.
+2. **All required secrets in staging:**
+   ```bash
+   wrangler secret put GARMIN_INBOUND_TOKEN --env staging
+   wrangler secret put LLM_API_KEY          --env staging
+   wrangler secret put GITHUB_JOURNAL_TOKEN --env staging
+   wrangler secret put RESEND_API_KEY       --env staging
+   wrangler secret put TODOIST_API_TOKEN    --env staging
+   ```
+3. **Journal repo (#56 P1-20) exists** with a working theme + the `JOURNAL_URL_TEMPLATE` pinned to its actual URL pattern.
+4. **`.env.replay`** in repo root (gitignored — `.env.*` pattern):
+   ```bash
+   STAGING_URL=https://trailscribe-staging.trailscribe.workers.dev/garmin/ipc
+   GARMIN_INBOUND_TOKEN=<paste the same value you used in `wrangler secret put`>
+   ```
+
+## Procedure (per command)
+
+The verification runs three times — once each for `!post`, `!mail`, `!todo`. Other commands (`!ping`, `!help`, `!cost`) are read-only or trivial-side-effect; replay safety for them is structural and covered by the unit tests in `tests/idempotency.test.ts` and `tests/p1-19-commands.test.ts`.
+
+### Per-run prep
+
+1. Edit `tests/fixtures/garmin-replay/<cmd>-replay.json`:
+   - `imei` → your allowlisted IMEI (must match `IMEI_ALLOWLIST` in staging vars).
+   - `timeStamp` → a unique integer. The idempotency key is derived from this; running with a stale value will collide with a previous test's record. Use `date +%s%3N` to generate a fresh one.
+   - For `mail-replay.json`: set the `to:` recipient in `freeText` to a held-out email you can monitor (don't use a real user's address).
+
+2. Open a second terminal:
+   ```bash
+   wrangler tail --env staging
+   ```
+   Leave it running so you can watch logs in real time.
+
+3. Run the driver:
+   ```bash
+   ./scripts/replay-test.sh post 10
+   # or: ./scripts/replay-test.sh mail 10
+   # or: ./scripts/replay-test.sh todo 10
+   ```
+
+   Each invocation sends 10 identical POSTs at 1s intervals. Every one should return HTTP 200 (the script asserts this).
+
+### Assertions
+
+#### Log assertions (from `wrangler tail`)
+
+In a clean replay run you should see:
+- **Exactly 1** first-delivery log line — the `event:"orchestrate_ok"` entry with `cmd:"<post|mail|todo>"`.
+- **Exactly 9** `event:"idempotent_replay"` log lines (for N=10).
+- **Zero** `event:"orchestrate_error"` or `event:"reply_send_failed"` lines.
+
+If you see more than one first-delivery, the idempotency record isn't being written — investigate `app.ts handleEvent`.
+
+If you see fewer than 9 replay logs, something else is intervening (auth failure, IMEI mismatch, bad-envelope) — the script's HTTP 200s alone don't catch this; check the log lines.
+
+#### Side-effect assertions (per command)
+
+**`post`** — exactly 1 new commit on the journal repo's `main`:
+
+```bash
+gh api "repos/$GITHUB_JOURNAL_REPO/commits?per_page=5&sha=main" \
+  --jq '.[].commit.message'
+```
+
+Look for one `trailscribe: <title>` commit whose title matches the LLM-generated title. If there are 10, replay safety is broken at the publish step.
+
+**`mail`** — exactly 1 message in Resend's outbound log:
+
+- Resend dashboard: <https://resend.com/emails> → filter by "to" matching the held-out recipient → confirm count = 1 in the relevant minute.
+- Or via API:
+  ```bash
+  curl -s -H "Authorization: Bearer $RESEND_API_KEY" \
+    "https://api.resend.com/emails?limit=20" | jq '.data | map(select(.to[0] == "<held-out>"))'
+  ```
+
+**`todo`** — exactly 1 new task in Todoist:
+
+```bash
+curl -s -H "Authorization: Bearer $TODOIST_API_TOKEN" \
+  "https://api.todoist.com/rest/v2/tasks" | jq '[.[] | select(.content | startswith("replay-test"))] | length'
+```
+
+Should print `1`.
+
+#### Ledger assertion (cross-cutting)
+
+After all three replay runs, send `!cost` from the device. Inspect the reply (or query monthly totals via KV):
+
+```bash
+wrangler kv:key get --binding=TS_LEDGER --env staging "ledger:$(date -u +%Y-%m)" | jq '.by_command'
+```
+
+Expected:
+```json
+{
+  "post": { "requests": 1, "usd_cost": <real-cost-from-LLM> },
+  "mail": { "requests": 1, "usd_cost": 0 },
+  "todo": { "requests": 1, "usd_cost": 0 }
+}
+```
+
+If any `requests` shows 10 instead of 1, the ledger write is happening on every replay rather than only on first delivery.
+
+## On failure: forensics
+
+If any side-effect count > 1, fetch the idempotency record to see which step re-executed:
+
+```bash
+# Compute the same key the Worker uses (sha256 over imei:ts:msgcode:contentHash).
+# Easier: just list all recent idem keys:
+wrangler kv:key list --binding=TS_IDEMPOTENCY --env staging | head
+
+# Inspect a specific record:
+wrangler kv:key get --binding=TS_IDEMPOTENCY --env staging "idem:<sha256-hex>" | jq
+```
+
+The `status` + `completedOps` + `opResults` fields reveal where the pipeline got stuck on the first run; the duplicate count tells you which step's `withCheckpoint` failed to short-circuit.
+
+If `status === "completed"` but a side-effect still duplicated, the bug is in `app.ts` — the replay short-circuit isn't firing before the dispatch.
+
+If `status` is `"processing"` or `"failed"` *and* a side-effect duplicated, the `withCheckpoint` itself isn't reading the cached `opResults` — most likely a serialization issue or a renamed `opName`.
+
+## Story completion note (paste-in template)
+
+When the run is clean, drop this note on issue #58 to close it:
+
+```
+## Session <YYYY-MM-DD> — P1-22 verified
+
+Procedure: ./scripts/replay-test.sh <cmd> 10 ran for post / mail / todo.
+
+Logs (wrangler tail):
+  post: 1 orchestrate_ok + 9 idempotent_replay (✓)
+  mail: 1 orchestrate_ok + 9 idempotent_replay (✓)
+  todo: 1 orchestrate_ok + 9 idempotent_replay (✓)
+
+Side effects:
+  post: <N>=1 commit on <journal-repo>/main (✓ no duplicates)
+  mail: <N>=1 message in Resend log to <held-out> (✓)
+  todo: <N>=1 task in Todoist (✓)
+
+Ledger by_command (post-run):
+  post: requests=1, usd_cost=$<real>
+  mail: requests=1, usd_cost=$0.00
+  todo: requests=1, usd_cost=$0.00
+
+Verdict: replay-safe. PRD criterion "0 duplicate side-effects across 10
+manual replays" met.
+```

--- a/scripts/replay-test.sh
+++ b/scripts/replay-test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# replay-test.sh — P1-22 idempotency replay verification (manual driver).
+#
+# Re-deliver the SAME Garmin webhook payload N times to staging and verify the
+# Worker:
+#   - returns HTTP 200 every time (Garmin retry-cascade gate);
+#   - emits exactly ONE first-delivery log + (N-1) "idempotent_replay" logs;
+#   - does NOT re-execute side-effects (no extra blog commit, email, or task).
+#
+# This is a manual driver: it sends the requests and prints the assertions
+# YOU need to verify in external systems (journal repo, Resend dashboard,
+# Todoist). It does not auto-verify those — they live behind separate APIs.
+#
+# Prerequisites (one-time, before first run):
+#   1. Phase 1 deployed to staging.
+#   2. Wrangler secrets present in staging:
+#        wrangler secret put GARMIN_INBOUND_TOKEN --env staging
+#        wrangler secret put LLM_API_KEY          --env staging
+#        wrangler secret put GITHUB_JOURNAL_TOKEN --env staging
+#        wrangler secret put RESEND_API_KEY       --env staging
+#        wrangler secret put TODOIST_API_TOKEN    --env staging
+#   3. Journal repo (P1-20 / #56) exists with a working theme.
+#   4. .env.replay exists in repo root with the matching token + IMEI.
+#
+# Per-run prep:
+#   1. Edit the matching tests/fixtures/garmin-replay/*.json file:
+#        - Set "imei" to your real allowlisted IMEI.
+#        - For mail-replay.json, set "to:" to a held-out recipient.
+#        - Pick a UNIQUE timeStamp (otherwise prior runs' idem records still
+#          match — set it to `date +%s%3N` if unsure).
+#   2. Pick a command: post | mail | todo
+#   3. Run:  ./scripts/replay-test.sh post 10
+#
+# Output:
+#   - Each curl prints HTTP status (expect 200 every time).
+#   - Tail wrangler logs in another terminal:  wrangler tail --env staging
+#     The first delivery should NOT log idempotent_replay; deliveries 2..N
+#     SHOULD log idempotent_replay every time.
+#
+# Post-run manual checks (the script prints these as a checklist):
+#   - GitHub journal repo (post): exactly 1 new commit with the test slug.
+#   - Resend dashboard       (mail): exactly 1 message to the held-out address.
+#   - Todoist                 (todo): exactly 1 new task.
+#   - !cost (run a !ping !cost from device): "post"/"mail"/"todo" by-command
+#     count incremented by exactly 1, not by N.
+
+set -euo pipefail
+
+CMD="${1:-}"
+N="${2:-10}"
+
+if [[ -z "$CMD" || ! "$CMD" =~ ^(post|mail|todo)$ ]]; then
+  echo "Usage: $0 <post|mail|todo> [N=10]" >&2
+  exit 64
+fi
+
+if ! [[ "$N" =~ ^[0-9]+$ ]] || (( N < 1 )); then
+  echo "N must be a positive integer; got: $N" >&2
+  exit 64
+fi
+
+# Load endpoint + bearer token from .env.replay (gitignored).
+ENV_FILE="$(dirname "$0")/../.env.replay"
+if [[ ! -f "$ENV_FILE" ]]; then
+  cat <<EOF >&2
+Missing $ENV_FILE. Create it with:
+
+  STAGING_URL=https://trailscribe-staging.trailscribe.workers.dev/garmin/ipc
+  GARMIN_INBOUND_TOKEN=<the staging bearer token, must match wrangler secret>
+
+This file is gitignored.
+EOF
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+if [[ -z "${STAGING_URL:-}" || -z "${GARMIN_INBOUND_TOKEN:-}" ]]; then
+  echo ".env.replay must export STAGING_URL and GARMIN_INBOUND_TOKEN" >&2
+  exit 1
+fi
+
+FIXTURE="$(dirname "$0")/../tests/fixtures/garmin-replay/${CMD}-replay.json"
+if [[ ! -f "$FIXTURE" ]]; then
+  echo "Fixture not found: $FIXTURE" >&2
+  exit 1
+fi
+
+# Sanity check the fixture has been customized.
+if grep -q "REPLACE_WITH_REAL_IMEI" "$FIXTURE"; then
+  cat <<EOF >&2
+$FIXTURE still contains REPLACE_WITH_REAL_IMEI placeholder.
+Edit it before running:
+  - "imei":     your allowlisted IMEI
+  - "timeStamp": a unique number (e.g. \$(date +%s%3N))
+  - For mail:    set "to:<recipient>" in freeText
+EOF
+  exit 1
+fi
+if [[ "$CMD" == "mail" ]] && grep -q "REPLACE_WITH_HELDOUT_RECIPIENT" "$FIXTURE"; then
+  echo "Set the to: recipient in $FIXTURE" >&2
+  exit 1
+fi
+
+echo "==================================================================="
+echo "P1-22 idempotency replay — $CMD × $N"
+echo "Endpoint: $STAGING_URL"
+echo "Fixture:  $FIXTURE"
+echo
+echo "Tail logs in another terminal:  wrangler tail --env staging"
+echo "==================================================================="
+echo
+
+for i in $(seq 1 "$N"); do
+  status=$(curl --silent --output /dev/null --write-out "%{http_code}" \
+    --max-time 30 \
+    -X POST "$STAGING_URL" \
+    -H "Authorization: Bearer $GARMIN_INBOUND_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data-binary "@$FIXTURE")
+  if [[ "$status" != "200" ]]; then
+    echo "[$i/$N] FAIL — got HTTP $status (expected 200; Garmin retry cascade triggered)"
+    exit 2
+  fi
+  echo "[$i/$N] HTTP $status"
+  # Brief pause so the wrangler tail output is readable.
+  sleep 1
+done
+
+cat <<EOF
+
+==================================================================="
+All $N requests returned HTTP 200.
+
+NOW VERIFY MANUALLY (the script can't reach these systems):
+
+[1] wrangler tail output should show:
+    - Exactly 1 first-delivery (event=orchestrate_ok or post/mail/todo log)
+    - Exactly $((N - 1)) "event":"idempotent_replay" lines
+
+[2] Side-effect verification per command:
+EOF
+
+case "$CMD" in
+  post)
+    echo "    - GitHub journal repo: exactly 1 new commit on \`main\`"
+    echo "      gh api repos/<owner>/<journal-repo>/commits --jq '.[0:3] | map(.commit.message)'"
+    ;;
+  mail)
+    echo "    - Resend dashboard: exactly 1 message to the held-out recipient"
+    echo "      https://resend.com/emails (filter by recent)"
+    ;;
+  todo)
+    echo "    - Todoist: exactly 1 new task"
+    echo "      https://todoist.com/app or curl -H 'Authorization: Bearer \$TODOIST_API_TOKEN' https://api.todoist.com/rest/v2/tasks"
+    ;;
+esac
+
+cat <<EOF
+
+[3] !cost from the device should show by_command["$CMD"] incremented by 1
+    (NOT by $N).
+
+[4] If any side-effect count > 1, replay safety is broken — file a bug
+    against P1-22 and inspect:
+        wrangler kv:key get --binding=TS_IDEMPOTENCY --env staging "idem:<key>"
+    The record's status + completedOps/opResults reveals which step
+    re-executed.
+EOF

--- a/tests/fixtures/garmin-replay/mail-replay.json
+++ b/tests/fixtures/garmin-replay/mail-replay.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "REPLACE_WITH_REAL_IMEI",
+      "messageCode": 3,
+      "freeText": "!mail to:REPLACE_WITH_HELDOUT_RECIPIENT@example.com subj:replay-test body:idempotency check",
+      "timeStamp": 1745596860000,
+      "addresses": [
+        { "address": "trailscribe@resend.dev" }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/post-replay.json
+++ b/tests/fixtures/garmin-replay/post-replay.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "REPLACE_WITH_REAL_IMEI",
+      "messageCode": 3,
+      "freeText": "!post replay-test alpenglow at sunset",
+      "timeStamp": 1745596800000,
+      "addresses": [
+        { "address": "trailscribe@resend.dev" }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/todo-replay.json
+++ b/tests/fixtures/garmin-replay/todo-replay.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "REPLACE_WITH_REAL_IMEI",
+      "messageCode": 3,
+      "freeText": "!todo replay-test idempotency check",
+      "timeStamp": 1745596920000,
+      "addresses": [
+        { "address": "trailscribe@resend.dev" }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Manual driver + runbook for the P1-22 idempotency replay verification. The verification is **manual** because asserting "exactly 1 commit / 1 email / 1 task" requires reaching into GitHub + Resend + Todoist — three separate APIs the Worker doesn't expose. The unit tests in `tests/idempotency.test.ts` + `tests/p1-16-post-pipeline.test.ts` already cover the structural replay safety; this procedure validates end-to-end against real staging.

## Files

- **`scripts/replay-test.sh`** — bash driver. POSTs the same payload N times to `/garmin/ipc` with bearer auth, asserts every response is HTTP 200, then prints the manual-verification checklist. Loads endpoint + token from `.env.replay` (gitignored via existing `.env.*` pattern). Sanity-checks placeholder strings are filled in before sending.
- **`tests/fixtures/garmin-replay/{post,mail,todo}-replay.json`** — V2 envelope shapes with `REPLACE_WITH_*` placeholders.
- **`docs/replay-verification.md`** — full runbook: prerequisites, per-run prep, log/side-effect/ledger assertions per command, forensics for failure modes, and a completion-note template to paste on #58 when the run is clean.

Closes #58.

## Test plan

- [x] `bash -n` syntax check on the driver — clean
- [x] Argument validation paths exercise correctly (no command, bad command, non-numeric N)
- [ ] **Manual run** against staging once #56 P1-20 + secrets land. Paste the completion note on #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)