### PR TITLE
fix(journal): _posts path template (Jekyll convention, not Hugo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Phase 0 complete (2026-04-24). All 20 P0 stories shipped.
 - `IPC_INBOUND_SENDER` — `Sender` field for outbound IPC Inbound messages (the on-device "From" string); defaults to `RESEND_FROM_EMAIL` but decoupled
 - `RESEND_FROM_EMAIL` — e.g. `trailscribe@resend.dev`
 - `RESEND_FROM_NAME` — e.g. `TrailScribe`
-- `JOURNAL_POST_PATH_TEMPLATE` — e.g. `content/posts/{yyyy}-{mm}-{dd}-{slug}.md`
+- `JOURNAL_POST_PATH_TEMPLATE` — e.g. `_posts/{yyyy}-{mm}-{dd}-{slug}.md`
 - `JOURNAL_URL_TEMPLATE` — public URL pattern for committed posts; pinned by P1-20
 
 ## Garmin IPC quick-ref (authoritative sources in `materials/`)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -382,7 +382,7 @@ If the same webhook replays after partial completion:
 
 ### Resolved 2026-04-22 (replaces "Still open" section below)
 
-- **D5. Blog platform:** **GitHub Pages + markdown commits via GitHub Contents API.** Journal lives in a dedicated repo (e.g., `brockamer/trailscribe-journal`); Worker commits `content/posts/YYYY-MM-DD-<slug>.md` with frontmatter. Theme TBD at Phase 0 (default: Jekyll `minima` for zero-config, swap to Hugo later if desired).
+- **D5. Blog platform:** **GitHub Pages + markdown commits via GitHub Contents API.** Journal lives in a dedicated repo (e.g., `brockamer/trailscribe-journal`); Worker commits `_posts/YYYY-MM-DD-<slug>.md` with frontmatter. Theme TBD at Phase 0 (default: Jekyll `minima` for zero-config, swap to Hugo later if desired).
 - **D8. Outbound email:** **Resend.** `RESEND_API_KEY` secret; `RESEND_FROM_EMAIL=trailscribe@resend.dev` for α, move to own-domain later. Replaces all Gmail OAuth bindings in §3.
 - **D9. Email-fallback reply:** **skipped for α.** If IPC Inbound returns 5xx after 3 retries (1s/4s/16s backoff), write ledger entry `reply_delivery: failed` and return 200 OK to Garmin. Side effects (blog post, email, task) still persist. Revisit in Phase 2 if reliability data warrants.
 
@@ -404,7 +404,7 @@ Options considered:
 → **My recommendation: GitHub Pages + markdown commits via GitHub Contents API.**
 - Reasons: you already have GitHub SSH/token set up; zero subscription; posts are durable markdown in a repo (easy to migrate, easy to audit, easy to edit after); Worker commits a file, done; satisfies Yuki-style "blog never dark" without vendor lock-in.
 - Tradeoff: requires picking a theme (Hugo minimal theme like `hugo-theme-terminal` or Jekyll `minima` — 30min setup) and wiring a deploy action (GitHub's built-in Pages auto-builds Jekyll; Hugo needs one Action). Theme/deploy setup happens once at Phase 0; not in the hot path.
-- Binding: repo name → `trailscribe-journal` or similar, public, branch `main`, path `content/posts/YYYY-MM-DD-<slug>.md`.
+- Binding: repo name → `trailscribe-journal` or similar, public, branch `main`, path `_posts/YYYY-MM-DD-<slug>.md`.
 
 → **Thumbs-up / thumbs-down, or name a different platform.** If thumbs-up, I'll default the adapter to GitHub Pages in the Phase 0 plan and you can later swap for Ghost with a single-file change.
 

--- a/plans/phase-1-alpha-mvp.md
+++ b/plans/phase-1-alpha-mvp.md
@@ -253,7 +253,7 @@ Reply budget is 320 chars (two SMS). Each `Message` field is hard-capped at 160 
 
 **Context.** `src/adapters/publish/github-pages.ts` is a stub. We commit one markdown file per `!post` to a dedicated journal repo (`GITHUB_JOURNAL_REPO`, e.g. `brockamer/trailscribe-journal`). Endpoint is the **GitHub Contents API**: `PUT /repos/{owner}/{repo}/contents/{path}` with a base64 file body and a commit message. Auth via fine-grained PAT with `contents:write` on exactly the journal repo.
 
-Path template comes from `JOURNAL_POST_PATH_TEMPLATE`, default `content/posts/{yyyy}-{mm}-{dd}-{slug}.md`. Public URL uses `JOURNAL_URL_TEMPLATE` (P1-04) so the reply link survives a theme swap.
+Path template comes from `JOURNAL_POST_PATH_TEMPLATE`, default `_posts/{yyyy}-{mm}-{dd}-{slug}.md`. Public URL uses `JOURNAL_URL_TEMPLATE` (P1-04) so the reply link survives a theme swap.
 
 The slug is derived from the narrative title (lowercase, alphanumerics + hyphens, ≤ 50 chars).
 
@@ -567,7 +567,7 @@ Every side-effecting step (4, 5, 8) goes through `withCheckpoint` (P1-13) so rep
 - [ ] Repo `brockamer/trailscribe-journal` (or whatever the user picks) created, public.
 - [ ] GitHub Pages enabled, source = `main` branch, `/` root.
 - [ ] Theme picked: Jekyll `minima` (recommended — zero-config, GitHub builds automatically) or Hugo `terminal`-style (needs an Action). Theme committed.
-- [ ] `content/posts/2026-04-26-hello.md` placeholder committed with the same frontmatter shape P1-08 emits; visible at the public Pages URL.
+- [ ] `_posts/2026-04-26-hello.md` placeholder committed with the same frontmatter shape P1-08 emits; visible at the public Pages URL.
 - [ ] **Pin `JOURNAL_URL_TEMPLATE`** in `wrangler.toml` to match the theme's actual URL pattern (Jekyll default: `{owner}.github.io/{repo}/{yyyy}/{mm}/{dd}/{slug}.html`). Verify by clicking the placeholder post's URL.
 - [ ] Fine-grained PAT with `contents:write` scoped to *only* this repo generated; stored as `GITHUB_JOURNAL_TOKEN` secret in staging + production via `wrangler secret put`.
 - [ ] `docs/setup-cloudflare.md` updated with the journal-repo setup steps (theme choice, Pages config, PAT scoping, URL template).

--- a/tests/github-pages.test.ts
+++ b/tests/github-pages.test.ts
@@ -32,7 +32,7 @@ beforeEach(() => {
     GITHUB_JOURNAL_REPO: "brockamer/trailscribe-journal",
     GITHUB_JOURNAL_BRANCH: "main",
     GITHUB_JOURNAL_TOKEN: "ghp_test_token_xyz123",
-    JOURNAL_POST_PATH_TEMPLATE: "content/posts/{yyyy}-{mm}-{dd}-{slug}.md",
+    JOURNAL_POST_PATH_TEMPLATE: "_posts/{yyyy}-{mm}-{dd}-{slug}.md",
     JOURNAL_URL_TEMPLATE: "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html",
   });
   fetchSpy = vi.fn();
@@ -79,7 +79,7 @@ describe("publishPost — happy path", () => {
       .mockResolvedValueOnce(new Response(null, { status: 404 })) // GET path: free
       .mockResolvedValueOnce(
         jsonResponse({
-          content: { sha: "blob-sha", path: "content/posts/2026-04-25-test.md", html_url: "x" },
+          content: { sha: "blob-sha", path: "_posts/2026-04-25-test.md", html_url: "x" },
           commit: { sha: "commit-sha-abc123" },
         }),
       );
@@ -95,7 +95,7 @@ describe("publishPost — happy path", () => {
     expect(result.url).toBe(
       "https://brockamer.github.io/trailscribe-journal/2026/04/25/test-title.html",
     );
-    expect(result.path).toBe("content/posts/2026-04-25-test-title.md");
+    expect(result.path).toBe("_posts/2026-04-25-test-title.md");
     expect(result.sha).toBe("commit-sha-abc123");
   });
 
@@ -248,7 +248,7 @@ describe("publishPost — slug collision", () => {
       now: () => NOW,
     });
 
-    expect(result.path).toBe("content/posts/2026-04-25-test-2.md");
+    expect(result.path).toBe("_posts/2026-04-25-test-2.md");
     expect(result.url).toContain("/2026/04/25/test-2.html");
     expect(fetchSpy).toHaveBeenCalledTimes(3);
   });

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -75,7 +75,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     IPC_INBOUND_SENDER: "trailscribe@resend.dev",
     RESEND_FROM_EMAIL: "trailscribe@resend.dev",
     RESEND_FROM_NAME: "TrailScribe",
-    JOURNAL_POST_PATH_TEMPLATE: "content/posts/{yyyy}-{mm}-{dd}-{slug}.md",
+    JOURNAL_POST_PATH_TEMPLATE: "_posts/{yyyy}-{mm}-{dd}-{slug}.md",
     JOURNAL_URL_TEMPLATE: "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html",
 
     GARMIN_INBOUND_TOKEN: "test-bearer-token-abcdef0123456789",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,7 +26,7 @@ IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@resend.dev"
 RESEND_FROM_EMAIL = "trailscribe@resend.dev"
 RESEND_FROM_NAME = "TrailScribe"
-JOURNAL_POST_PATH_TEMPLATE = "content/posts/{yyyy}-{mm}-{dd}-{slug}.md"
+JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
 JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html"
 
 # KV namespaces — provisioned per env (dev main + dev preview + staging + production).
@@ -87,7 +87,7 @@ IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@resend.dev"
 RESEND_FROM_EMAIL = "trailscribe@resend.dev"
 RESEND_FROM_NAME = "TrailScribe (staging)"
-JOURNAL_POST_PATH_TEMPLATE = "content/posts/{yyyy}-{mm}-{dd}-{slug}.md"
+JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
 JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html"
 
 [[env.staging.kv_namespaces]]
@@ -129,7 +129,7 @@ IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@resend.dev"
 RESEND_FROM_EMAIL = "trailscribe@resend.dev"
 RESEND_FROM_NAME = "TrailScribe"
-JOURNAL_POST_PATH_TEMPLATE = "content/posts/{yyyy}-{mm}-{dd}-{slug}.md"
+JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
 JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html"
 
 [[env.production.kv_namespaces]]


### PR DESCRIPTION
## Summary

`JOURNAL_POST_PATH_TEMPLATE` was set to the Hugo convention `content/posts/{yyyy}-{mm}-{dd}-{slug}.md`. Jekyll ignores files outside `_posts/`, so `publishPost` would have committed cleanly to GitHub but the public URL would 404. Discovered while bootstrapping `brockamer/trailscribe-journal` (#56 P1-20): the placeholder post under `_posts/` rendered correctly; under `content/posts/` it would not have.

## Updates

- `wrangler.toml` — dev/staging/production all pinned to `_posts/{yyyy}-{mm}-{dd}-{slug}.md`.
- `tests/helpers/env.ts` + `tests/github-pages.test.ts` — same template + path-expectation strings.
- `CLAUDE.md` / `docs/PRD.md` / `plans/phase-1-alpha-mvp.md` — doc references corrected so future readers don't hit the same trap.

No code logic changed — `publishPost` substitutes whatever template the env hands it.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 187 passing (no regressions)
- [ ] CI green
- [ ] Manual verify after deploy: P1-16 staging burn-in produces a real post visible at the predicted URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)