### PR TITLE
fix(auth): Garmin IPC Outbound uses X-Outbound-Auth-Token (not Authorization: Bearer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,9 +115,9 @@ Phase 0 complete (2026-04-24). All 20 P0 stories shipped.
 ## External services
 
 **Secrets (Wrangler Secrets):**
-- `GARMIN_INBOUND_TOKEN` — static bearer; verify `Authorization: Bearer <token>` on Outbound webhooks
+- `GARMIN_INBOUND_TOKEN` — static token; verify `X-Outbound-Auth-Token: <token>` on Outbound webhooks (Garmin sends raw token in custom header, not standard `Authorization: Bearer`)
 - `GARMIN_IPC_INBOUND_API_KEY` — `X-API-Key` for Garmin IPC Inbound
-- `GARMIN_IPC_INBOUND_BASE_URL` — per-tenant (e.g. `https://ipcinbound.inreachapp.com/api`)
+- `GARMIN_IPC_INBOUND_BASE_URL` — per-tenant; **host only, no path** (e.g. `https://ipcinbound.inreachapp.com`). Code appends `/api/Messaging/Message`. Found in Garmin Explore → IPC → Inbound Settings → "Inbound URL".
 - `IMEI_ALLOWLIST` — comma-sep accepted IMEIs (defense-in-depth)
 - `LLM_API_KEY` — OpenRouter API key (provider-neutral; supersedes `OPENAI_API_KEY` per #31)
 - `TODOIST_API_TOKEN`

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -370,7 +370,7 @@ If the same webhook replays after partial completion:
 
 ### Signed off (2026-04-22)
 
-- **D1. Inbound auth:** Static bearer token stored as `GARMIN_INBOUND_TOKEN` Wrangler Secret. Verify `Authorization: Bearer <token>` on every Outbound webhook. Rotation yearly.
+- **D1. Inbound auth:** Static token stored as `GARMIN_INBOUND_TOKEN` Wrangler Secret. Garmin IPC Outbound sends the token as a raw value in the `X-Outbound-Auth-Token` header (not the standard `Authorization: Bearer` form — verified against the live Garmin gateway 2026-04-25). Rotation yearly.
 - **D2. Garmin Professional tier:** Available. Full IPC Outbound + IPC Inbound path enabled.
 - **D3. Schema version:** V2 for α. Code tolerant of V3/V4 fields.
 - **D4. Daily token budget:** `DAILY_TOKEN_BUDGET=50000` tokens/day (≈ 150 `!post` narratives/day). Revise after one week of real usage.

--- a/docs/garmin-setup.md
+++ b/docs/garmin-setup.md
@@ -45,14 +45,16 @@ have multiple devices).
 4. **Authorization:** **Static Token**. Paste the value of
    `GARMIN_INBOUND_TOKEN` (generate via `openssl rand -hex 32`; see
    [`setup-cloudflare.md`](setup-cloudflare.md) §2).
-   - Garmin will include this value in the `Authorization` header on every
-     POST; TrailScribe verifies it before any side-effect work.
+   - Garmin sends this as a raw token in the `X-Outbound-Auth-Token`
+     header (not the standard `Authorization: Bearer` form — verified
+     empirically against the live Garmin gateway, 2026-04-25). TrailScribe
+     verifies it before any side-effect work.
 5. **Save.** Send `!ping` from the device to validate — watch `wrangler tail`.
 
 ### What the Worker does with the POST
 
 Per event in the envelope:
-1. Verify `Authorization: Bearer <token>`.
+1. Verify `X-Outbound-Auth-Token: <token>` (Garmin's custom header, not standard `Authorization`).
 2. Validate the V2 envelope shape.
 3. Confirm `imei` is in the allowlist.
 4. Compute composite idempotency key: `sha256(imei : timeStamp : messageCode : sha256(freeText))`.

--- a/scripts/replay-test.sh
+++ b/scripts/replay-test.sh
@@ -116,7 +116,7 @@ for i in $(seq 1 "$N"); do
   status=$(curl --silent --output /dev/null --write-out "%{http_code}" \
     --max-time 30 \
     -X POST "$STAGING_URL" \
-    -H "Authorization: Bearer $GARMIN_INBOUND_TOKEN" \
+    -H "X-Outbound-Auth-Token: $GARMIN_INBOUND_TOKEN" \
     -H "Content-Type: application/json" \
     --data-binary "@$FIXTURE")
   if [[ "$status" != "200" ]]; then

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,8 +55,8 @@ export function makeApp() {
    *      cascade for app-level failures.
    */
   app.post("/garmin/ipc", async (c) => {
-    const auth = c.req.header("authorization");
-    const expected = `Bearer ${c.env.GARMIN_INBOUND_TOKEN}`;
+    const auth = c.req.header("x-outbound-auth-token");
+    const expected = c.env.GARMIN_INBOUND_TOKEN;
     if (!auth || auth !== expected) {
       log({ event: "auth_fail", level: "warn", path: "/garmin/ipc" });
       return c.text("ok", 200);

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 async function postIpc(body: unknown, opts: { bearer?: string } = {}): Promise<Response> {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (opts.bearer !== undefined) {
-    headers["authorization"] = `Bearer ${opts.bearer}`;
+    headers["x-outbound-auth-token"] = opts.bearer;
   }
   return app.request(
     "/garmin/ipc",
@@ -83,7 +83,7 @@ describe("Worker /garmin/ipc — Phase 0 behavior", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+          "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
         },
         body: "{ this is not json",
       },
@@ -111,7 +111,7 @@ describe("Worker /garmin/ipc — Phase 0 behavior", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${env2.GARMIN_INBOUND_TOKEN}`,
+          "x-outbound-auth-token": env2.GARMIN_INBOUND_TOKEN,
         },
         body: JSON.stringify(fixture),
       },

--- a/tests/p1-01-guards.test.ts
+++ b/tests/p1-01-guards.test.ts
@@ -76,7 +76,7 @@ async function postIpc(body: unknown): Promise<Response> {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
       },
       body: JSON.stringify(body),
     },

--- a/tests/p1-16-post-pipeline.test.ts
+++ b/tests/p1-16-post-pipeline.test.ts
@@ -70,7 +70,7 @@ async function postIpc(body: unknown): Promise<Response> {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
       },
       body: JSON.stringify(body),
     },

--- a/tests/p1-17-18-mail-todo-pipelines.test.ts
+++ b/tests/p1-17-18-mail-todo-pipelines.test.ts
@@ -57,7 +57,7 @@ async function postIpc(body: unknown): Promise<Response> {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
       },
       body: JSON.stringify(body),
     },

--- a/tests/p1-19-commands.test.ts
+++ b/tests/p1-19-commands.test.ts
@@ -66,7 +66,7 @@ async function postIpc(body: unknown): Promise<Response> {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${env.GARMIN_INBOUND_TOKEN}`,
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
       },
       body: JSON.stringify(body),
     },


### PR DESCRIPTION
## Summary

- Discovered live during 2026-04-25 P1 burn-in: Garmin IPC Outbound sends the static token as `X-Outbound-Auth-Token: <raw-token>`, **not** `Authorization: Bearer <token>`. Every webhook was returning `auth_fail` despite matching secret values.
- Fix the Worker auth check, update 5 test fixtures + the replay driver, and correct PRD §8 D1, CLAUDE.md, and `docs/garmin-setup.md` to reflect what the live gateway actually sends.
- Bonus: corrected `CLAUDE.md` `GARMIN_IPC_INBOUND_BASE_URL` example (was `…/api`, should be host only — code appends `/api/Messaging/Message`).

## Why our docs guessed wrong

`materials/Garmin IPC Outbound.txt` (v2.0.8 spec) describes "static token auth" without naming the header — it's set by the Garmin Connect/Explore portal at IPC Outbound configuration time. Convention suggested `Authorization: Bearer`; the live gateway disagrees. Now documented with date stamp.

## Test plan

- [x] All 187 unit tests pass under new fixture header (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] Deployed to staging (`afd90c5d`) — `!ping` from real device returns `auth_pass`, orchestrator dispatches, reply lands on device almost instantly via IPC Inbound (verified 2026-04-25 ~10:22 PT)
- [ ] CI green on PR
- [ ] After merge: deploy to production via `pnpm deploy:prod`

## Notes for reviewer

- Worker still returns `200` on `auth_fail` (deliberate — avoids triggering Garmin's 12h × 5d retry-suspend penalty on token misconfig). Failed auth is observable only in logs, by design (PRD §5).
- Outbound calls to Garmin IPC Inbound (us → device) still use `X-API-Key`, unchanged. Only the inbound (Garmin → us) auth header was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)