### PR TITLE
fix(todoist): migrate to consolidated api/v1 endpoint

### DIFF
--- a/scripts/burn-in.sh
+++ b/scripts/burn-in.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# scripts/burn-in.sh — P1-21 staging burn-in driver.
+#
+# Sends one fixture per command (!ping, !help, !cost, !post, !mail, !todo) to
+# the staging Worker with a fresh timeStamp each, exercising real third-party
+# APIs (OpenRouter, Resend, Todoist, GitHub Pages). Records each response and
+# prints a summary table.
+#
+# Prerequisites:
+#   1. .env.replay populated with STAGING_URL and GARMIN_INBOUND_TOKEN
+#      (gitignored; same file replay-test.sh uses).
+#   2. `wrangler tail --env staging` running in another terminal (for log
+#      capture into the P1-21 completion note).
+#
+# This is a one-shot burn-in, NOT a replay/dedupe test (use replay-test.sh
+# for that). Each command fires exactly once with a unique timestamp.
+
+set -euo pipefail
+
+ENV_FILE="$(dirname "$0")/../.env.replay"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing $ENV_FILE — see scripts/replay-test.sh for format." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+
+if [[ -z "${STAGING_URL:-}" || -z "${GARMIN_INBOUND_TOKEN:-}" ]]; then
+  echo ".env.replay must export STAGING_URL and GARMIN_INBOUND_TOKEN" >&2
+  exit 1
+fi
+
+FIXDIR="$(dirname "$0")/../tests/fixtures/garmin-replay"
+
+# Order matters: cheap+side-effect-free commands first, expensive last,
+# so the run aborts early on any failure without spending money.
+CMDS=(ping help cost post mail todo)
+
+printf "%-6s  %-6s  %s\n" "CMD" "STATUS" "FIXTURE"
+echo "------  ------  -------"
+
+for CMD in "${CMDS[@]}"; do
+  FIXTURE="$FIXDIR/${CMD}-burn-in.json"
+  if [[ ! -f "$FIXTURE" ]]; then
+    echo "MISSING fixture: $FIXTURE" >&2
+    exit 1
+  fi
+  # Stamp the fixture with the current epoch ms so each run gets a fresh
+  # idempotency key (no replay dedup).
+  TS=$(date +%s%3N)
+  PAYLOAD=$(jq --arg ts "$TS" '.Events[0].timeStamp = ($ts | tonumber)' "$FIXTURE")
+
+  STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" \
+    --max-time 30 \
+    -X POST "$STAGING_URL" \
+    -H "X-Outbound-Auth-Token: $GARMIN_INBOUND_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data "$PAYLOAD")
+
+  printf "%-6s  %-6s  %s\n" "!$CMD" "$STATUS" "$(basename "$FIXTURE") (ts=$TS)"
+
+  if [[ "$STATUS" != "200" ]]; then
+    echo "ABORT: $CMD returned $STATUS — Garmin would retry; investigate before continuing" >&2
+    exit 2
+  fi
+
+  # Brief pause between commands so async work (LLM call, email send, GitHub
+  # commit) settles in tail and we don't run into provider-side rate limits.
+  sleep 5
+done
+
+echo
+echo "All 6 commands returned 200. Now verify in:"
+echo "  - wrangler tail (orchestrate_ok per command)"
+echo "  - GitHub journal repo: 1 new commit from !post"
+echo "  - your inbox: 1 email from !mail"
+echo "  - Todoist: 1 new task from !todo"
+echo "  - !cost output: by-command counts incremented (or inspect TS_LEDGER KV)"

--- a/src/adapters/tasks/todoist.ts
+++ b/src/adapters/tasks/todoist.ts
@@ -1,6 +1,9 @@
 import type { Env } from "../../env.js";
 
-const TODOIST_URL = "https://api.todoist.com/rest/v2/tasks";
+// Todoist consolidated all REST/Sync APIs into a unified `/api/v1/` namespace.
+// Old `/rest/v2/tasks` returns HTTP 410 Gone (verified against live API
+// 2026-04-25). Request/response shape is unchanged.
+const TODOIST_URL = "https://api.todoist.com/api/v1/tasks";
 const TODOIST_TASK_URL = "https://todoist.com/showTask?id=";
 const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
 

--- a/tests/fixtures/garmin-replay/cost-burn-in.json
+++ b/tests/fixtures/garmin-replay/cost-burn-in.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "300052030374220",
+      "messageCode": 3,
+      "freeText": "!cost",
+      "timeStamp": 1666666666000,
+      "addresses": [
+        {
+          "address": "trailscribe@resend.dev"
+        }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/help-burn-in.json
+++ b/tests/fixtures/garmin-replay/help-burn-in.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "300052030374220",
+      "messageCode": 3,
+      "freeText": "!help",
+      "timeStamp": 1666666666000,
+      "addresses": [
+        {
+          "address": "trailscribe@resend.dev"
+        }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/mail-burn-in.json
+++ b/tests/fixtures/garmin-replay/mail-burn-in.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "300052030374220",
+      "messageCode": 3,
+      "freeText": "!mail to:brockamer@gmail.com subj:burn-in body:P1-21 staging burn-in test",
+      "timeStamp": 1666666666000,
+      "addresses": [
+        {
+          "address": "trailscribe@resend.dev"
+        }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/ping-burn-in.json
+++ b/tests/fixtures/garmin-replay/ping-burn-in.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "300052030374220",
+      "messageCode": 3,
+      "freeText": "!ping",
+      "timeStamp": 1666666666000,
+      "addresses": [
+        {
+          "address": "trailscribe@resend.dev"
+        }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/post-burn-in.json
+++ b/tests/fixtures/garmin-replay/post-burn-in.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "300052030374220",
+      "messageCode": 3,
+      "freeText": "!post burn-in test alpenglow at the lake",
+      "timeStamp": 1666666666000,
+      "addresses": [
+        {
+          "address": "trailscribe@resend.dev"
+        }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/garmin-replay/todo-burn-in.json
+++ b/tests/fixtures/garmin-replay/todo-burn-in.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2.0",
+  "Events": [
+    {
+      "imei": "300052030374220",
+      "messageCode": 3,
+      "freeText": "!todo P1-21 burn-in test task",
+      "timeStamp": 1666666666000,
+      "addresses": [
+        {
+          "address": "trailscribe@resend.dev"
+        }
+      ],
+      "point": {
+        "latitude": 37.1682,
+        "longitude": -118.5891,
+        "altitude": 3307,
+        "gpsFix": 2,
+        "course": 180,
+        "speed": 0
+      },
+      "status": {
+        "autonomous": 1,
+        "lowBattery": 0,
+        "intervalChange": 0,
+        "resetDetected": 0
+      }
+    }
+  ]
+}

--- a/tests/todoist.test.ts
+++ b/tests/todoist.test.ts
@@ -46,7 +46,7 @@ describe("addTask — happy path", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(String(url)).toBe("https://api.todoist.com/rest/v2/tasks");
+    expect(String(url)).toBe("https://api.todoist.com/api/v1/tasks");
     expect((init as RequestInit).method).toBe("POST");
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers["Authorization"]).toBe(`Bearer ${env.TODOIST_API_TOKEN}`);


### PR DESCRIPTION
## Summary

Discovered during P1-21 staging burn-in. Todoist consolidated all REST/Sync APIs into a unified `/api/v1/` namespace; the old `/rest/v2/tasks` endpoint now returns HTTP 410 Gone. Empirically verified against the live API (2026-04-25):

| Endpoint | Status |
|---|---|
| `GET /rest/v2/tasks` | 410 (gone) |
| `GET /api/v1/tasks` | 401 (auth required, endpoint live) |
| `GET /sync/v9/sync` | 410 (gone) |

Request and response shapes are unchanged; only the URL path differs. The adapter's body shape (`{ content, description }`) and response handling (`{ id }`) work as-is.

## Test plan

- [x] `pnpm test` — all 187 tests pass with the updated URL constant
- [x] `pnpm typecheck` clean
- [x] Re-deployed to staging (`4e2f0c32`); `!todo` burn-in returns `orchestrate_ok` with no `todo_create_failed` error
- [ ] CI green on PR

## Bonus tooling

Adds `scripts/burn-in.sh` — the P1-21 burn-in driver (one fixture per command, fresh timestamps each, cheap-first abort-on-failure ordering). Fixtures live in `tests/fixtures/garmin-replay/{ping,help,cost,post,mail,todo}-burn-in.json` with the project tenant's real IMEI baked in.

## Notes

P1-21 (#57) **remains blocked** on two separate issues this burn-in surfaced:
1. OpenRouter `LLM_API_KEY` returning 401 "User not found" (filing as a separate bug)
2. Resend testing-tier restriction — needs domain verification per #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)