### PR TITLE
feat(safety): IPC_INBOUND_DRY_RUN flag for staging campaigns (#92)

### DIFF
--- a/docs/setup-cloudflare.md
+++ b/docs/setup-cloudflare.md
@@ -304,6 +304,34 @@ Once staging has held up for a week (or sooner if you're impatient), repeat
 [`deploy-cloudflare.yml`](../.github/workflows/deploy-cloudflare.yml). Update
 Garmin Portal Connect to point at the production URL.
 
+## Synthetic load runs against staging (`IPC_INBOUND_DRY_RUN`)
+
+When you need to exercise the full pipeline (parse → orchestrate → narrative
+LLM → publish → ledger) without delivering real SMS to your inReach device —
+e.g. P1-23-style cost measurement campaigns or load tests — flip the staging
+dry-run flag.
+
+Two ways to enable it:
+
+1. **Inline edit + redeploy (recommended for one-offs).** Edit
+   `wrangler.toml` `[env.staging.vars]` to set `IPC_INBOUND_DRY_RUN = "true"`,
+   run `pnpm deploy:staging`, run your campaign, then revert and redeploy.
+   The flag is checked into git in the OFF position — leaving it ON in a
+   committed file is the loud, visible failure mode (CI / code review will
+   catch it).
+
+2. **CLI override (faster).** `pnpm exec wrangler deploy --env staging
+   --var IPC_INBOUND_DRY_RUN:true` — applies just for that deploy. Re-run the
+   normal `pnpm deploy:staging` to revert.
+
+When ON, `sendReply` short-circuits the Garmin POST and emits a structured
+`ipc_inbound_dry_run` log line (visible in `wrangler tail --env staging`)
+showing IMEI, sender, page count, total chars, and a per-page preview.
+
+**Production is locked.** `parseEnv` throws at Worker startup if
+`TRAILSCRIBE_ENV=production` AND `IPC_INBOUND_DRY_RUN=true` — production must
+always deliver real replies.
+
 ## Rotation
 
 - `GARMIN_INBOUND_TOKEN`: yearly. Generate new, update both Wrangler Secret

--- a/src/adapters/outbound/garmin-ipc-inbound.ts
+++ b/src/adapters/outbound/garmin-ipc-inbound.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../../env.js";
+import { ipcInboundDryRun } from "../../env.js";
 import { log } from "../logging/worker-logs.js";
 
 const MAX_MESSAGE_CHARS = 160;
@@ -85,6 +86,23 @@ export async function sendReply(
         message: `Message length ${m.length} exceeds 160-char Iridium cap (caller bug — page-split before calling sendReply)`,
       });
     }
+  }
+
+  // Dry-run short-circuit: log what would have been sent, return success
+  // without contacting Garmin. Validation above still runs so dry-run callers
+  // catch length-cap regressions. Production sets are blocked by parseEnv.
+  if (ipcInboundDryRun(env)) {
+    const totalChars = messages.reduce((n, m) => n + m.length, 0);
+    log({
+      event: "ipc_inbound_dry_run",
+      level: "info",
+      imei,
+      sender: env.IPC_INBOUND_SENDER,
+      message_pages: messages.length,
+      total_chars: totalChars,
+      preview: messages.map((m) => m.slice(0, 80)),
+    });
+    return { count: messages.length };
   }
 
   const delay = opts.delay ?? defaultDelay;

--- a/src/env.ts
+++ b/src/env.ts
@@ -25,6 +25,7 @@ export interface Env {
   DAILY_TOKEN_BUDGET: string;
   IPC_SCHEMA_VERSION: string;
   IPC_INBOUND_SENDER: string;
+  IPC_INBOUND_DRY_RUN: string;
   RESEND_FROM_EMAIL: string;
   RESEND_FROM_NAME: string;
   JOURNAL_POST_PATH_TEMPLATE: string;
@@ -77,6 +78,7 @@ export const EnvSchema = z.object({
   DAILY_TOKEN_BUDGET: z.string(),
   IPC_SCHEMA_VERSION: z.enum(["2", "3", "4"]),
   IPC_INBOUND_SENDER: z.string().min(1),
+  IPC_INBOUND_DRY_RUN: z.string(),
   RESEND_FROM_EMAIL: z.string().email(),
   RESEND_FROM_NAME: z.string().min(1),
   JOURNAL_POST_PATH_TEMPLATE: z.string().min(1),
@@ -106,7 +108,15 @@ export function parseEnv(env: unknown): Env {
       .join("\n");
     throw new Error(`Invalid Worker Env bindings:\n${issues}`);
   }
-  return result.data as Env;
+  const parsed = result.data as Env;
+  // Prod must never silently mute device sends. Dry-run is a staging/dev-only
+  // safety rail; in prod it would hide real delivery failures.
+  if (parsed.TRAILSCRIBE_ENV === "production" && ipcInboundDryRun(parsed)) {
+    throw new Error(
+      "Invalid Worker Env: IPC_INBOUND_DRY_RUN must not be 'true' when TRAILSCRIBE_ENV=production",
+    );
+  }
+  return parsed;
 }
 
 /** Parse the comma-separated IMEI allowlist into a Set for O(1) lookup. */
@@ -117,6 +127,16 @@ export function imeiAllowSet(env: Env): Set<string> {
 /** Parse the boolean-ish APPEND_COST_SUFFIX var. */
 export function appendCostSuffix(env: Env): boolean {
   return env.APPEND_COST_SUFFIX.toLowerCase() === "true";
+}
+
+/**
+ * Parse IPC_INBOUND_DRY_RUN. When true, `sendReply` short-circuits without
+ * calling Garmin IPC Inbound. Used to exercise the full pipeline (parse →
+ * orchestrate → narrative → publish → ledger) in staging without delivering
+ * real SMS to the operator's device. Forbidden in production (see parseEnv).
+ */
+export function ipcInboundDryRun(env: Env): boolean {
+  return env.IPC_INBOUND_DRY_RUN.toLowerCase() === "true";
 }
 
 /** Parse DAILY_TOKEN_BUDGET (0 = unlimited). */

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "vitest";
+import { parseEnv, ipcInboundDryRun } from "../src/env.js";
+import { makeTestEnv } from "./helpers/env.js";
+
+describe("parseEnv — IPC_INBOUND_DRY_RUN production guard", () => {
+  test("throws when TRAILSCRIBE_ENV=production AND IPC_INBOUND_DRY_RUN=true", () => {
+    const bad = makeTestEnv({
+      TRAILSCRIBE_ENV: "production",
+      IPC_INBOUND_DRY_RUN: "true",
+    });
+    expect(() => parseEnv(bad)).toThrow(/IPC_INBOUND_DRY_RUN must not be 'true'/);
+  });
+
+  test("allows TRAILSCRIBE_ENV=production with IPC_INBOUND_DRY_RUN=false", () => {
+    const ok = makeTestEnv({
+      TRAILSCRIBE_ENV: "production",
+      IPC_INBOUND_DRY_RUN: "false",
+    });
+    expect(() => parseEnv(ok)).not.toThrow();
+  });
+
+  test("allows IPC_INBOUND_DRY_RUN=true on staging (and any non-production env)", () => {
+    for (const envName of ["staging", "development", "test"]) {
+      const ok = makeTestEnv({
+        TRAILSCRIBE_ENV: envName,
+        IPC_INBOUND_DRY_RUN: "true",
+      });
+      expect(() => parseEnv(ok)).not.toThrow();
+    }
+  });
+});
+
+describe("ipcInboundDryRun helper", () => {
+  test("returns true for 'true' (case-insensitive), false otherwise", () => {
+    expect(ipcInboundDryRun(makeTestEnv({ IPC_INBOUND_DRY_RUN: "true" }))).toBe(true);
+    expect(ipcInboundDryRun(makeTestEnv({ IPC_INBOUND_DRY_RUN: "TRUE" }))).toBe(true);
+    expect(ipcInboundDryRun(makeTestEnv({ IPC_INBOUND_DRY_RUN: "True" }))).toBe(true);
+    expect(ipcInboundDryRun(makeTestEnv({ IPC_INBOUND_DRY_RUN: "false" }))).toBe(false);
+    expect(ipcInboundDryRun(makeTestEnv({ IPC_INBOUND_DRY_RUN: "" }))).toBe(false);
+    expect(ipcInboundDryRun(makeTestEnv({ IPC_INBOUND_DRY_RUN: "yes" }))).toBe(false);
+  });
+});

--- a/tests/garmin-ipc-inbound.test.ts
+++ b/tests/garmin-ipc-inbound.test.ts
@@ -226,3 +226,56 @@ describe("sendReply — retry semantics (5xx/429)", () => {
     expect(sleptMs).toEqual([1000, 4000, 16000]);
   });
 });
+
+describe("sendReply — dry-run flag", () => {
+  test("IPC_INBOUND_DRY_RUN=true: no fetch, returns count=pages, emits ipc_inbound_dry_run log", async () => {
+    env = makeTestEnv({ IPC_INBOUND_DRY_RUN: "true" });
+
+    const result = await sendReply(
+      "123456789012345",
+      ["page one (1/2)", "page two (2/2)"],
+      env,
+      { delay: noDelay },
+    );
+
+    expect(result).toEqual({ count: 2 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const dryRunEvent = loggedEvents().find((e) => e.event === "ipc_inbound_dry_run");
+    expect(dryRunEvent).toBeDefined();
+    expect(dryRunEvent?.imei).toBe("123456789012345");
+    expect(dryRunEvent?.message_pages).toBe(2);
+    expect(dryRunEvent?.total_chars).toBe("page one (1/2)".length + "page two (2/2)".length);
+    expect(dryRunEvent?.sender).toBe(env.IPC_INBOUND_SENDER);
+  });
+
+  test("IPC_INBOUND_DRY_RUN=true still validates length cap (catches caller bugs in dry-run too)", async () => {
+    env = makeTestEnv({ IPC_INBOUND_DRY_RUN: "true" });
+    const tooLong = "x".repeat(161);
+
+    await expect(sendReply("123456789012345", [tooLong], env, { delay: noDelay })).rejects.toThrow(
+      /exceeds 160-char/,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("IPC_INBOUND_DRY_RUN=false (default): hits fetch as normal", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(200, { count: 1 }));
+
+    await sendReply("123456789012345", ["pong"], env, { delay: noDelay });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const dryRunEvent = loggedEvents().find((e) => e.event === "ipc_inbound_dry_run");
+    expect(dryRunEvent).toBeUndefined();
+  });
+
+  test("case-insensitive: 'TRUE' and 'True' also short-circuit", async () => {
+    for (const flag of ["TRUE", "True", "tRuE"]) {
+      fetchSpy.mockClear();
+      env = makeTestEnv({ IPC_INBOUND_DRY_RUN: flag });
+      const result = await sendReply("123456789012345", ["pong"], env, { delay: noDelay });
+      expect(result).toEqual({ count: 1 });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -73,6 +73,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     DAILY_TOKEN_BUDGET: "50000",
     IPC_SCHEMA_VERSION: "2",
     IPC_INBOUND_SENDER: "trailscribe@resend.dev",
+    IPC_INBOUND_DRY_RUN: "false",
     RESEND_FROM_EMAIL: "trailscribe@resend.dev",
     RESEND_FROM_NAME: "TrailScribe",
     JOURNAL_POST_PATH_TEMPLATE: "_posts/{yyyy}-{mm}-{dd}-{slug}.md",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,6 +24,7 @@ APPEND_COST_SUFFIX = "false"
 DAILY_TOKEN_BUDGET = "50000"
 IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
+IPC_INBOUND_DRY_RUN = "false"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
@@ -85,6 +86,11 @@ APPEND_COST_SUFFIX = "false"
 DAILY_TOKEN_BUDGET = "50000"
 IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
+# Default off; flip to "true" + redeploy when running synthetic !post / !mail
+# / !todo campaigns against staging that exercise the full pipeline without
+# delivering real SMS to the operator's device. Production deploys are
+# blocked from setting this — see src/env.ts parseEnv guard.
+IPC_INBOUND_DRY_RUN = "false"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe (staging)"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
@@ -127,6 +133,8 @@ APPEND_COST_SUFFIX = "false"
 DAILY_TOKEN_BUDGET = "50000"
 IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
+# Production must always deliver. parseEnv throws if this is "true" + env=production.
+IPC_INBOUND_DRY_RUN = "false"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"


### PR DESCRIPTION
## Summary

- Adds `IPC_INBOUND_DRY_RUN` env var; when `"true"` on staging, `sendReply` short-circuits the Garmin POST and emits a structured `ipc_inbound_dry_run` log line instead — full pipeline (parse → orchestrate → narrative LLM → publish → ledger) still runs, real SMS does not go out.
- Production-locked: `parseEnv` throws at Worker startup if `TRAILSCRIBE_ENV=production` AND `IPC_INBOUND_DRY_RUN=true`.
- Length-cap validation (160-char Iridium limit) still runs in dry-run so caller bugs surface in test traffic.

## Why

P1-23 cost measurement (#59) accidentally delivered ~39 SMS to the operator's real inReach because there was no path to exercise the LLM/journal pipeline without the final IPC Inbound hop. The cost AC only needs the LLM call + ledger write, not device delivery. This converts that mistake from "remember to manually rewrite the fixture IMEI" (which doesn't even work — allowlist would reject it) into "the staging environment is configured for the test you're running."

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test`: 195/195 pass (8 new — 4 IPC dry-run + 4 env-guard)
- [ ] Post-merge: deploy to staging, set `IPC_INBOUND_DRY_RUN=true`, fire one `!post` fixture, verify in `wrangler tail`:
  - `ipc_inbound_dry_run` log line appears with correct page count
  - no IPC Inbound POST in network logs
  - journal repo gets a new commit (publish path still runs)
  - ledger increments (cost path still runs)
  - device receives no SMS
- [ ] Post-merge: revert flag to `"false"`, redeploy, verify normal path still delivers (single `!ping` test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)