### PR TITLE
chore(plans): archive phase-1-alpha-mvp.md

### DIFF
--- a/plans/archived/2026-04/phase-1-alpha-mvp.md
+++ b/plans/archived/2026-04/phase-1-alpha-mvp.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #34, #34 on 2026-04-25. Final decisions captured in issue body.**
+---
+
 # Phase 1 — α-MVP
 
 **Goal:** From a Garmin inReach Mini 3 Plus, send any of the six α-MVP commands (`!post`, `!mail`, `!todo`, `!ping`, `!help`, `!cost`) and receive a valid reply on the device — end-to-end through real third-party APIs, with the per-transaction cost ≤ \$0.05 and idempotent against Garmin's retry storms.


### PR DESCRIPTION
All Phase 1 stories shipped; plan moved to `plans/archived/2026-04/`. Issue #34 (Phase 1 epic) had its `## Planning` section updated by archive-plan.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)