### PR TITLE
chore(ci): bump runner Node from 20 to 22 to match local dev VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
@@ -59,7 +59,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck


### PR DESCRIPTION
## Summary

- Bumps `node-version` from `"20"` to `"22"` in `.github/workflows/ci.yml` (1 occurrence) and `.github/workflows/deploy-cloudflare.yml` (2 occurrences — staging + production deploy jobs).
- Aligns CI/CD runners with the new local dev environment (Ubuntu 26.04 dev VM, Node 22.22.1 system apt) after the migration off the aarch64 Chromebook (was Node 20.20.2).
- Cloudflare prod is unaffected either way — `workerd` has its own runtime, independent of the runner Node version.

## Test plan

- [ ] CI completes successfully on this PR (typecheck + Vitest + ESLint) under Node 22 — this is itself the proof.
- [ ] After merge, manually trigger `Deploy to Cloudflare` workflow with `target=staging` and confirm staging deploy still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)