### PR TITLE
chore(docs): fix stale fixture path in setup-cloudflare.md (closes #74)

### DIFF
--- a/docs/setup-cloudflare.md
+++ b/docs/setup-cloudflare.md
@@ -275,7 +275,7 @@ curl -s "$STAGING_URL/health" | jq .
 curl -s -X POST "$STAGING_URL/garmin/ipc" \
   -H "X-Outbound-Auth-Token: $GARMIN_INBOUND_TOKEN" \
   -H "Content-Type: application/json" \
-  --data @tests/fixtures/garmin-outbound-v2-freetext.json
+  --data @tests/fixtures/garmin/free-text-ping.json
 # Expect: ok
 ```
 


### PR DESCRIPTION
## Summary

One-line edit. The staging-deploy smoke-test curl example in `docs/setup-cloudflare.md` referenced `tests/fixtures/garmin-outbound-v2-freetext.json`, which P1-01 (PR #60) moved to `tests/fixtures/garmin/free-text-ping.json`. Doc was missed at the time.

## Test plan

- [x] No other stale refs anywhere in `docs/` (`grep -rnE "garmin-outbound-v2-freetext|tests/fixtures/garmin-outbound" docs/` returns nothing).
- [x] New fixture exists and is non-empty: `tests/fixtures/garmin/free-text-ping.json` (558 bytes).
- [x] `scripts/replay-test.sh` and `scripts/burn-in.sh` already use the new path successfully (this morning's migration check ran the suite green at 191/191).
- [ ] Live staging curl — skipped. Would trigger a real Garmin Inbound reply unless dry-run is flipped first; the fix is a path-string correction, not a behavior change. Existing scripts already exercise this path against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)