### PR TITLE
chore(scripts): cost-measurement.sh — wrangler auth precheck (closes #102)

### DIFF
--- a/scripts/cost-measurement.sh
+++ b/scripts/cost-measurement.sh
@@ -35,6 +35,21 @@ if [[ ! -f "$FIXTURE" ]]; then
   exit 1
 fi
 
+# Wrangler auth precheck — required for the pre/post `kv key get` reads. Without
+# auth, the silent `|| echo "{}"` fallback below would mask access errors and
+# produce a misleading delta in the summary block. NB: `wrangler whoami` exits 0
+# even when unauthenticated; we must grep the output text.
+echo "--- Wrangler auth precheck ---"
+WHOAMI_OUT=$(pnpm exec wrangler whoami 2>&1 || true)
+if echo "$WHOAMI_OUT" | grep -qE "not authenticated|not logged in"; then
+  echo "ERROR: wrangler is not authenticated. Cost-measurement reads staging KV;" >&2
+  echo "       silent failure here would mask access errors and skew the summary." >&2
+  echo "  Fix: pnpm exec wrangler login" >&2
+  exit 1
+fi
+echo "  ✓ wrangler authenticated"
+echo
+
 # Varied note text spanning the three personas + prompt-length variance, so
 # the per-call cost reflects realistic field traffic rather than 20× the
 # same prompt.


### PR DESCRIPTION
## Summary

Adds an explicit auth precheck at the top of `scripts/cost-measurement.sh` so an unauthenticated `wrangler` state is caught before any side-effecting work (instead of being silently masked by the `|| echo "{}"` fallback on the pre/post ledger reads, which would skew the summary delta).

## Why this is needed (and why a simple `! wrangler whoami` doesn't work)

`wrangler whoami` **exits 0 even when unauthenticated** — only the text output reveals the state. The precheck has to grep the output, not rely on exit code. Pattern matches both `"not authenticated"` and `"not logged in"` to tolerate minor CLI-version drift.

## Acceptance verification

- [x] **Syntactic check:** `bash -n scripts/cost-measurement.sh` exits 0.
- [x] **Negative case (unauth):** Ran the script in the current unauth state on this dev VM (post-migration, `wrangler login` not yet re-run). Aborted at the precheck with exit 1 *before* loading `.env.replay`, *before* any curl, *before* any KV read. Error message:
  ```
  ERROR: wrangler is not authenticated. Cost-measurement reads staging KV;
         silent failure here would mask access errors and skew the summary.
    Fix: pnpm exec wrangler login
  ```
- [x] **Positive-case regex:** simulated authenticated whoami output (`👋 You are logged in with an OAuth Token, associated with the email …`) does not match the negative pattern; the precheck falls through to the existing flow.

## Out of scope (per the issue's "Optionally" clause)

The issue's third acceptance bullet says the silent `|| echo "{}"` fallback on `kv key get` could be tightened to exit non-zero on failure. Left as-is here because:
1. The fallback's *primary* failure mode (auth missing) is now caught up-front by the precheck.
2. The fallback also legitimately handles the "key not found" case for the first run of any month (`ledger:YYYY-MM` doesn't exist yet).

If we want to discriminate "auth/network error" vs "key missing" robustly, that's a follow-up. But it's not strictly required for #102's primary intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)