### PR TITLE
chore(scripts): cost-measurement.sh — dry-run safety check (closes #103)

### DIFF
--- a/scripts/cost-measurement.sh
+++ b/scripts/cost-measurement.sh
@@ -8,13 +8,28 @@
 # Prereqs:
 #   1. .env.replay populated with STAGING_URL and GARMIN_INBOUND_TOKEN.
 #   2. wrangler authenticated (run `pnpm exec wrangler login` once).
-#   3. Optionally: `wrangler tail --env staging` running in another terminal
+#   3. Staging Worker deployed with IPC_INBOUND_DRY_RUN=true, OR pass
+#      --allow-real-sends to fire real Garmin replies. Default: aborts if
+#      dry-run is off, since 20× real device sends is rarely intended.
+#   4. Optionally: `wrangler tail --env staging` running in another terminal
 #      for live spot-check of orchestrate_ok / narrative_diag.
+#
+# Flags:
+#   --allow-real-sends   Skip the dry-run safety abort and proceed even if
+#                        IPC_INBOUND_DRY_RUN is false on staging.
 #
 # Outputs: a summary block at the end suitable for pasting as the P1-23
 # story-completion note on issue #59.
 
 set -euo pipefail
+
+ALLOW_REAL_SENDS=false
+for arg in "$@"; do
+  case "$arg" in
+    --allow-real-sends) ALLOW_REAL_SENDS=true ;;
+    *) echo "Unknown flag: $arg" >&2; exit 1 ;;
+  esac
+done
 
 ENV_FILE="$(dirname "$0")/../.env.replay"
 if [[ ! -f "$ENV_FILE" ]]; then
@@ -48,6 +63,53 @@ if echo "$WHOAMI_OUT" | grep -qE "not authenticated|not logged in"; then
   exit 1
 fi
 echo "  ✓ wrangler authenticated"
+echo
+
+# Dry-run safety check — query the deployed staging Worker's /health endpoint
+# (which exposes IPC_INBOUND_DRY_RUN as `dry_run: bool`) and abort if it's off
+# unless --allow-real-sends was passed. Without this, forgetting to deploy
+# with --var IPC_INBOUND_DRY_RUN:true fires 20 real Garmin replies — the
+# specific foot-gun that caused issue #59's first attempt to over-spam the
+# operator's device.
+HEALTH_URL="${STAGING_URL%/garmin/ipc}/health"
+echo "--- Staging dry-run safety check ---"
+echo "  GET $HEALTH_URL"
+HEALTH=$(curl --silent --max-time 10 --fail "$HEALTH_URL" 2>&1) || {
+  echo "ERROR: failed to fetch $HEALTH_URL — staging worker unreachable?" >&2
+  echo "$HEALTH" >&2
+  exit 1
+}
+DRY_RUN=$(echo "$HEALTH" | jq -r '.dry_run // "missing"')
+case "$DRY_RUN" in
+  true)
+    echo "  ✓ staging is in dry-run mode (no real device sends)"
+    ;;
+  false)
+    if [[ "$ALLOW_REAL_SENDS" == "true" ]]; then
+      echo "  ⚠  staging is NOT in dry-run mode and --allow-real-sends was passed."
+      echo "     20× real Garmin device replies WILL fire on the operator's inReach."
+      echo "     Sleeping 5s — Ctrl-C now to abort."
+      sleep 5
+    else
+      echo "ERROR: staging worker has IPC_INBOUND_DRY_RUN=false." >&2
+      echo "       This script would fire 20 real Garmin device replies." >&2
+      echo "  Fix:  pnpm exec wrangler deploy --env staging --var IPC_INBOUND_DRY_RUN:true" >&2
+      echo "  Or:   re-run with --allow-real-sends if real-device sends are intended." >&2
+      exit 1
+    fi
+    ;;
+  missing)
+    echo "ERROR: /health response did not include dry_run field. Worker may be" >&2
+    echo "       running an older revision than src/app.ts. Redeploy staging." >&2
+    echo "  Response: $HEALTH" >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: unexpected dry_run value: $DRY_RUN" >&2
+    echo "  Response: $HEALTH" >&2
+    exit 1
+    ;;
+esac
 echo
 
 # Varied note text spanning the three personas + prompt-length variance, so

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "./env.js";
-import { appendCostSuffix, imeiAllowSet } from "./env.js";
+import { appendCostSuffix, imeiAllowSet, ipcInboundDryRun } from "./env.js";
 import type { CommandResult, GarminEnvelope, GarminEvent } from "./core/types.js";
 import {
   idempotencyKey,
@@ -31,6 +31,7 @@ export function makeApp() {
       ok: true,
       env: c.env.TRAILSCRIBE_ENV,
       timestamp: new Date().toISOString(),
+      dry_run: ipcInboundDryRun(c.env),
     }),
   );
 

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -130,12 +130,18 @@ describe("Worker sanity routes", () => {
     expect(await res.text()).toContain("TrailScribe");
   });
 
-  test("GET /health returns env + timestamp JSON", async () => {
+  test("GET /health returns env + timestamp + dry_run JSON", async () => {
     const res = await app.request("/health", {}, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { ok: boolean; env: string; timestamp: string };
+    const body = (await res.json()) as {
+      ok: boolean;
+      env: string;
+      timestamp: string;
+      dry_run: boolean;
+    };
     expect(body.ok).toBe(true);
     expect(body.env).toBe("test");
     expect(typeof body.timestamp).toBe("string");
+    expect(body.dry_run).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds a deployed-state dry-run safety check to `scripts/cost-measurement.sh`. The script now queries the staging Worker's `/health` endpoint and aborts the campaign if `IPC_INBOUND_DRY_RUN` is off — unless `--allow-real-sends` is explicitly passed.

This closes the foot-gun that bit issue #59's first attempt: the script's docs said "set IPC_INBOUND_DRY_RUN=true on staging first" but didn't verify, so forgetting the flag fired 20 real Garmin device replies on the operator's inReach.

## Bundled change: `/health` extension

The script's safety check needs to know what's actually running on staging — not what's in `wrangler.toml` (CLI `--var` overrides aren't reflected there). The cheapest reliable signal is to ask the deployed worker.

`/health` is extended *additively* to include `dry_run: bool`, sourced from the existing `ipcInboundDryRun(env)` helper:

```diff
 c.json({
   ok: true,
   env: c.env.TRAILSCRIBE_ENV,
   timestamp: new Date().toISOString(),
+  dry_run: ipcInboundDryRun(c.env),
 }),
```

No PII or secret exposure; `IPC_INBOUND_DRY_RUN` being on/off is operational metadata, not a credential.

## Behavior matrix

| `/health` `dry_run` | `--allow-real-sends` | Result |
|---|---|---|
| `true` | (any) | ✓ proceed |
| `false` | absent | ❌ abort with remediation hint |
| `false` | passed | ⚠ proceed after loud warning + 5s Ctrl-C window |
| missing field | (any) | ❌ abort (worker is older revision; needs redeploy) |
| `/health` unreachable | (any) | ❌ abort with curl error |

Remediation hint when dry_run=false:
```
ERROR: staging worker has IPC_INBOUND_DRY_RUN=false.
       This script would fire 20 real Garmin device replies.
  Fix:  pnpm exec wrangler deploy --env staging --var IPC_INBOUND_DRY_RUN:true
  Or:   re-run with --allow-real-sends if real-device sends are intended.
```

## On the `--allow-real-sends` flag (per the issue's "decide" criterion)

Exposed deliberately — there are legitimate reasons to fire a real-device campaign (validating IPC Inbound itself, end-to-end smoke after Garmin tenant changes, etc.). Bare presence of the flag isn't sufficient: the script also pauses 5s and prints a loud "Ctrl-C now to abort" line before firing, so a fat-fingered invocation can still be caught. Documented in the script header.

## Test plan

- [x] `bash -n scripts/cost-measurement.sh` clean.
- [x] Negative case (current dev VM, wrangler unauth): aborts at the prior `wrangler-auth` precheck before reaching dry-run logic — earliest-fail ordering preserved.
- [x] Unknown flag (`--bogus`): rejected with exit 1.
- [x] Full Vitest suite: **191/191 pass.** New `/health` test asserts `dry_run=false` on the test-env default.
- [ ] **Live staging verification skipped** — wrangler isn't authenticated on this dev VM (post-migration; `wrangler login` not yet re-run), so I can't redeploy + curl `/health` against staging. Worth running once before the next real cost-measurement campaign:
   1. `pnpm exec wrangler login`
   2. `pnpm deploy:staging` (deploys the new `/health` field)
   3. `bash scripts/cost-measurement.sh` — should abort with the dry_run=false remediation since staging currently has the flag off.
   4. `pnpm exec wrangler deploy --env staging --var IPC_INBOUND_DRY_RUN:true`
   5. `bash scripts/cost-measurement.sh` — should pass the safety check and run the full campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)