### PR TITLE
chore(wrangler): pin account_id so the runner skips /memberships lookup

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,7 @@
 
 name = "trailscribe"
 main = "src/index.ts"
+account_id = "d445b6851a9736b713eca837cf6254fd"
 compatibility_date = "2026-04-01"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
## Summary

Surfaced during post-migration auth setup on the new dev VM. With `CLOUDFLARE_API_TOKEN` created from the dashboard's **"Edit Cloudflare Workers"** template, every wrangler operation failed with HTTP 400 / code 9106:

```
✘ A request to the Cloudflare API (/memberships) failed.
  Authentication failed (status: 400) [code: 9106]
```

Root cause: wrangler 3.114.17 calls `GET /memberships` at startup to discover the account, but the "Edit Cloudflare Workers" template doesn't include `User → Memberships → Read` permission. Pinning `account_id` lets wrangler skip the discovery call entirely.

## Why account_id in source is OK

`account_id` is an identifier, not a credential. Cloudflare's own docs say it is safe to commit to source control. The repo is public (MIT-licensed), and many public OSS Workers repos pin theirs the same way.

## Verified after this change

- `pnpm exec wrangler kv namespace list` → returns all **16** namespaces (4 bindings × 4 environments).
- `pnpm exec wrangler secret list --env staging` → returns all **10** expected secrets:
  - `GARMIN_INBOUND_TOKEN`, `GARMIN_IPC_INBOUND_API_KEY`, `GARMIN_IPC_INBOUND_BASE_URL`
  - `IMEI_ALLOWLIST`
  - `LLM_API_KEY`
  - `TODOIST_API_TOKEN`
  - `RESEND_API_KEY`
  - `GITHUB_JOURNAL_REPO`, `GITHUB_JOURNAL_BRANCH`, `GITHUB_JOURNAL_TOKEN`
- `pnpm typecheck` clean (defensive — config-only change, doesn't touch TS).

## Test plan

- [x] CI green on this PR.
- [ ] After merge: any new contributor can `pnpm exec wrangler ...` with just an "Edit Cloudflare Workers" token (no `--var` / `account_id` env var needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)