### PR TITLE
chore(ci): re-enable auto-deploy-production on push to main

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -49,9 +49,7 @@ jobs:
           command: deploy --env staging
 
   deploy-production:
-    # TEMP: gated to manual dispatch until P0-07 (KV namespaces) + CF secrets are set.
-    # Re-enable `github.ref == 'refs/heads/main'` once the first successful prod deploy lands.
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'production'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.target == 'production')
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## Summary

- Restores `if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.target == 'production')` on the `deploy-production` job
- Removes the `TEMP:` comment block that was gating prod to `workflow_dispatch`-only
- Preserves the manual dispatch path for ad-hoc redeploys

Closes #33. Production secrets + the first prod deploy landed under #32 / #111, so the temporary gate is no longer needed.

## Test plan

- [ ] CI passes (typecheck + tests + lint already green locally — 191/191 tests, no type errors, no lint errors)
- [ ] Merging this PR pushes to `main` and triggers the `deploy-production` job
- [ ] `deploy-production` job succeeds end-to-end (this is the third acceptance bullet on #33 — the next push to `main` runs deploy-production)
- [ ] Manual `workflow_dispatch → production` still works (verified by inspection of `if:` condition; not exercised in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)