### PR TITLE
docs: pin device-side recipient + Include Location convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,21 @@ environments) is documented in
 configuration (bearer token, X-API-Key, IMEI) is in
 [`docs/garmin-setup.md`](docs/garmin-setup.md).
 
+On the device, save **`trailscribe@tx.trailscribe.net`** once as a contact
+named `TrailScribe` and pick it as the recipient for every `!command`. Keep
+the per-message *Include Location* toggle off — the Worker reads GPS from the
+webhook payload, so the device-side share is redundant. Full rationale in
+[`docs/garmin-setup.md`](docs/garmin-setup.md) §3a.
+
 ```bash
 pnpm deploy:staging                      # wrangler deploy --env staging
 pnpm deploy:prod                         # wrangler deploy --env production
 ```
 
-Pushes to `staging/**` branches auto-deploy to staging via
+Pushes to `staging/**` branches auto-deploy to staging, and pushes to `main`
+auto-deploy to production, via
 [`.github/workflows/deploy-cloudflare.yml`](.github/workflows/deploy-cloudflare.yml).
-Production deploy is currently gated to manual `workflow_dispatch` until the
-first prod deploy lands; it'll flip back to auto-on-`main` after that.
+A manual `workflow_dispatch` is also available for either target.
 
 ## Documentation
 

--- a/docs/field-commands.md
+++ b/docs/field-commands.md
@@ -2,6 +2,12 @@
 
 TrailScribe is controlled entirely via short commands sent from your Garmin inReach device. Commands always begin with an exclamation mark (`!`) and should be terse enough to fit in a single SMS. Replies are kept to two SMS messages or less.
 
+## Recipient
+
+Send every `!command` to **`trailscribe@tx.trailscribe.net`** (matches `IPC_INBOUND_SENDER` in `wrangler.toml`). Save it once on the device as a contact named `TrailScribe` and pick that contact for every outbound message — Garmin's Portal Connect tenant relays *every* outbound message to TrailScribe's webhook regardless of recipient, but using the right address makes replies thread correctly on the device.
+
+Keep the device's per-message **Include Location** toggle **off** for routine `!command` traffic — the Worker reads GPS from the Garmin Outbound webhook payload, so the device-side share is redundant and pollutes the displayed reply with a Google Maps URL the Mini 3 Plus can't open offline.
+
 ## Command summary
 
 | Command | Syntax | Description |

--- a/docs/garmin-setup.md
+++ b/docs/garmin-setup.md
@@ -75,6 +75,28 @@ Per event in the envelope:
   Support to resume.
 - Messages older than 5 days in the queue are dropped.
 
+## 3a. Device-side conventions for the operator
+
+These two device settings were surfaced during the production turn-on and are
+worth pinning before the first real `!command` from the field.
+
+**Save TrailScribe as a contact.** Add a contact entry on the inReach (Garmin
+Explore app → Contacts → New) named `TrailScribe` with email
+`trailscribe@tx.trailscribe.net`. Pick that contact as the recipient for every
+outbound `!command`. Mechanically, Portal Connect IPC Outbound forwards
+*every* device message to TrailScribe's webhook regardless of the chosen
+recipient — but the address still matters because IPC Inbound replies show up
+on-device as a thread keyed off the original "To". Sending to the right
+address keeps replies visible in one thread.
+
+**Keep "Include Location" off for routine commands.** The per-message
+*Include Location* toggle on the Mini 3 Plus, when on, attaches a Google Maps
+URL to the displayed reply (cosmetic, device-side; the webhook payload is
+unchanged). The URL is unusable on the offline device and wastes display real
+estate. Commands that need a GPS fix (`!post`, `!mail`, `!todo`, future
+`!where` / `!weather`) read it from the Garmin Outbound `point` field on the
+webhook side — the device-side share is redundant.
+
 ## 4. IPC Inbound (TrailScribe → device)
 
 1. **Portal Connect → Admin Controls → Portal Connect → Inbound Settings →


### PR DESCRIPTION
## Summary

Pins two operator-facing conventions surfaced during #111 production turn-on:

- **Recipient:** every `!command` goes to `trailscribe@tx.trailscribe.net` (matches `IPC_INBOUND_SENDER`). Save it once on the device as a contact named `TrailScribe`.
- **Include Location toggle:** keep it off for routine `!command` traffic — the Worker reads GPS from the Garmin Outbound webhook payload, so the device-side share is redundant and pollutes the displayed reply.

Closes #121.

Three doc edits + one drift fix:
- `docs/field-commands.md` — new "Recipient" section above the command summary
- `docs/garmin-setup.md` — new §3a "Device-side conventions for the operator"
- `README.md` — quick-start mention with rationale link
- `README.md` — refresh stale "production deploy gated to workflow_dispatch" paragraph (auto-on-main is back as of #126/#33)

## Test plan

- [ ] CI passes (no code change; pure docs)
- [ ] Diff renders correctly on GitHub (tables + `§3a` anchor link from README)
- [ ] Operator can follow the README quick-start to add the TrailScribe contact entry on the inReach and pick it for the next `!ping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)