### PR TITLE
docs: reconcile PRD + CLAUDE.md to Phase 2 active

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,18 +71,19 @@ docs/
   PRD.md                        # canonical product/engineering spec
   architecture.md               # updated for Workers
   garmin-setup.md               # updated for IPC Outbound bearer + IPC Inbound X-API-Key
-  commands.md                   # MVP + deferred cmds
+  field-commands.md             # MVP + deferred cmds (operator-facing reference)
   archive/                      # old Pipedream/n8n/Workers-minimal docs (deprecated but kept for ref)
 materials/                      # input PDFs + extracted txt; don't edit
-plans/                          # per-milestone sprint plans (phase-0-scaffolding.md, etc.)
+plans/                          # per-milestone sprint plans (active: phase-2-extended-commands.md; archived under archived/2026-MM/)
 ```
 
 ## Status
 
-- **Phase 0 — Workers scaffold:** complete 2026-04-24. All 20 P0 stories shipped. Staging Worker live at `https://trailscribe-staging.trailscribe.workers.dev`; bearer auth + IMEI allowlist + KV idempotency verified against the canonical V2 fixture; 16 KV namespaces provisioned across dev/staging/prod; CI green on PR (typecheck + Vitest + ESLint).
-- **Phase 1 — α-MVP:** code substantively shipped 2026-04-25 → 2026-04-26 (P1-17, P1-18, P1-20, P1-21, P1-22, P1-23). All 6 commands (`!post`, `!mail`, `!todo`, `!ping`, `!help`, `!cost`) return real responses on staging; replay verification + cost measurement complete; OpenRouter LLM layer live (`anthropic/claude-sonnet-4-6`); epic #30 + doc-reconciliation #31 closed 2026-04-26. Closing the milestone is now gated on **#111** — production traffic turn-on with the Mini 3 Plus against the production Worker. Plan: `plans/phase-1-alpha-mvp.md`.
-- **Production-readiness — current live phase** (milestone due 2026-05-31): 4 open items — custom domain (#26), re-enable auto-deploy on push to main (#33; currently `workflow_dispatch`-only after first prod deploy landed under #32), Garmin Pro tenant downgrade (#14, blocked on Garmin support reply) → device user swap (#15, queued behind #14).
-- **Future arc on the board:** Phase 2 — extended commands (#98, the 8 deferred α commands) and Phase 3 — Durable Objects + D1 migration (#99) filed 2026-04-26 as Low-priority Backlog umbrellas. Promote when their predecessors close.
+- **Phase 0 — Workers scaffold:** complete 2026-04-24. All 20 P0 stories shipped.
+- **Phase 1 — α-MVP:** complete 2026-04-27. Epic #30 closed 2026-04-26; close gate #111 (production traffic turn-on with the Mini 3 Plus against the production Worker) verified 2026-04-27. All 6 commands (`!post`, `!mail`, `!todo`, `!ping`, `!help`, `!cost`) return real responses on production; replay verification + cost measurement complete; OpenRouter LLM layer live (`anthropic/claude-sonnet-4-6`). Plan archived at `plans/archived/2026-04/phase-1-alpha-mvp.md`.
+- **Production-readiness:** complete 2026-04-28. All 8 milestone issues closed: shipped #32, #33 (auto-deploy on push to main re-enabled in #126), #121 (device-side recipient + Include-Location convention pinned in #127); closed-as-not-planned #14, #15, #26 (operator scope decision: personal-project housekeeping, no custom domain).
+- **Phase 2 — extended commands:** **active phase as of 2026-04-28.** Plan: `plans/phase-2-extended-commands.md`. Epic #98 (8 deferred α commands: `!where`, `!weather`, `!drop`, `!brief`, `!ai`, `!camp`, `!share`, `!blast`). Single-operator scope; KV-only state; no β-launch milestone. Sub-issues #112–#119 are sprint-ready when promoted from Backlog.
+- **Phase 3 — DO + D1 migration:** filed as epic #99 (Low-priority Backlog). Promote when Phase 2 closes.
 
 ## Conventions
 
@@ -147,7 +148,7 @@ plans/                          # per-milestone sprint plans (phase-0-scaffoldin
 ## Workflow
 
 - **jared** manages the board: https://github.com/users/brockamer/projects/3 (see `docs/project-board.md`).
-- Active plan: `plans/phase-0-scaffolding.md` (linked to epic #29).
+- Active plan: `plans/phase-2-extended-commands.md` (linked to epic #98).
 - Git: `origin` = `https://github.com/brockamer/trailscribe.git`, default branch `main`.
 - Commit sign-off: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,9 +1,9 @@
 # TrailScribe — Product Requirements Document
 
-**Status:** **Signed off 2026-04-22.** All decisions D1–D9 resolved. Proceed to Phase 0 (see `plans/phase-0-scaffolding.md`).
+**Status:** Signed off 2026-04-22. Phase 0 (scaffolding) shipped 2026-04-24. Phase 1 (α-MVP, six commands end-to-end on production) shipped 2026-04-26 with the prod-traffic close gate (#111) verified 2026-04-27. **Currently:** Phase 2 — extended commands. Plan: `plans/phase-2-extended-commands.md`.
 **Owner:** Brock Amer
-**Updated:** 2026-04-22
-**Scope:** α-MVP (Phase 1). Later phases referenced for alignment, not specified in full.
+**Updated:** 2026-04-28
+**Scope:** α-MVP (Phase 1) is the canonical scope of this document. Phase 2 (the eight deferred commands) is detailed in `plans/phase-2-extended-commands.md`; Phase 3+ referenced here for alignment, not specified in full.
 
 ---
 
@@ -32,7 +32,7 @@ TrailScribe is an AI-native serverless agent that transforms satellite messages 
 
 ### Non-goals (MVP)
 - No web dashboard, no photo upload, no multi-user/team features, no SOS integration, no voice, no offline-device logic.
-- No `!blast`, `!share`, `!camp`, `!brief`, `!drop`, `!where`, `!ai` commands. All deferred (see §8).
+- No `!where`, `!weather`, `!drop`, `!brief`, `!ai`, `!camp`, `!share`, `!blast` commands during α-MVP. All eight deferred to Phase 2 (see §2 deferrals table and `plans/phase-2-extended-commands.md`).
 - No Pipedream / n8n / generic deploy. Workers-only for α.
 - No non-inReach device support. Architecture is adapter-based; other devices deferred.
 
@@ -53,18 +53,20 @@ TrailScribe is an AI-native serverless agent that transforms satellite messages 
 
 ### Explicit deferrals (with reason)
 
-| Command / feature | Deferred to | Why deferred |
-|---|---|---|
-| `!where` | Phase 2 | Bandwidth-expensive pure-read; replaces MapShare (user already has). Low marginal value vs. map links in every reply. |
-| `!drop` (FieldLog) | Phase 2 | Requires persistent FieldLog store (D1 table or sheet). MVP punts structured journaling; unstructured `!post` covers the journaling narrative. |
-| `!brief` | Phase 2 | Depends on FieldLog + ledger + message history aggregation. Nothing to summarize until `!drop`/`!post` volume exists. |
-| `!camp` | Phase 3 | Real web search integration; heavy on tokens and latency. Fails satellite UX without tight constraints we haven't proven yet. |
-| `!ai <q>` | Phase 3 | Large AI replies chunked to SMS is a UX research problem (see radio-llm precedent). MVP embeds AI in `!post`'s narrative where structure is constrained. |
-| `!share` | Phase 4 | Variant of `!mail`; adds contact-book config. Marginal over `!mail` with a manual address. |
-| `!blast` | Phase 4 | Broadcast to groups needs address-book config + multi-recipient error handling. Not blocking MVP. |
-| Photos / media | Post-v1.0 | Schema V4 + R2 + image resizing. Big ask; MVP proves text workflow first. |
-| Web dashboard | Post-v1.0 | Trip visualization is a separate product surface. MVP is headless. |
-| `!weather` | Phase 2 | Referenced in Marcus's deck example; not in the "three commands" summary. Cheap to add post-α once `context` module is real. |
+The eight commands deferred from α-MVP all ship in **Phase 2** (epic #98) — see `plans/phase-2-extended-commands.md` for sequencing and per-command acceptance. The "why deferred" column captures why each was *not* in α-MVP; the "Phase 2 shape" column notes how Phase 2 absorbs the original concern. Earlier versions of this table split these across Phases 2/3/4 by complexity; that split has been collapsed into a single Phase 2 with internal sequencing because the transport boundary (Workers + KV + same orchestrator) is identical for all eight.
+
+| Command / feature | Deferred to | Why deferred from α | Phase 2 shape |
+|---|---|---|---|
+| `!where` | Phase 2 | Bandwidth-expensive pure-read; replaces MapShare (user already has). Low marginal value vs. map links in every reply. | Story P2-03; reuses `reverseGeocode`. |
+| `!weather` | Phase 2 | Referenced in Marcus's deck example; not in the "three commands" summary. Cheap to add post-α once `context` module is real. | Story P2-04; reuses `currentWeather`. |
+| `!drop` (FieldLog) | Phase 2 | Requires persistent FieldLog store. MVP punts structured journaling; unstructured `!post` covers the journaling narrative. | Story P2-05; FieldLog on KV with bounded retention (P2-01). D1 migration stays in Phase 3. |
+| `!brief` | Phase 2 | Depends on FieldLog + ledger + message history aggregation. Nothing to summarize until `!drop`/`!post` volume exists. | Story P2-06; LLM summarization with overflow-to-email path. |
+| `!ai <q>` | Phase 2 | Large AI replies chunked to SMS is a UX research problem (see radio-llm precedent). MVP embeds AI in `!post`'s narrative where structure is constrained. | Story P2-07; ≤320 char on device, longer answers route to email via Resend (mirrors `!post`'s overflow pattern). |
+| `!camp` | Phase 2 | Real web search integration is heavy on tokens and latency; fails satellite UX without tight constraints. | Story P2-08 ships LLM-only first cut with "may be outdated" disclaimer. Real web search is filed as P2-08b follow-up — not blocking Phase 2 close. |
+| `!share` | Phase 2 | Variant of `!mail`; adds contact-book config. Marginal over `!mail` with a manual address. | Story P2-10; alias resolution via env-var address book (P2-09). |
+| `!blast` | Phase 2 | Broadcast to groups needs address-book config + multi-recipient error handling. Not blocking MVP. | Story P2-11; per-recipient send with partial-failure tolerance. |
+| Photos / media | Post-v1.0 | Schema V4 + R2 + image resizing. Big ask; α proves text workflow first. | Out of scope for Phase 2. |
+| Web dashboard | Post-v1.0 | Trip visualization is a separate product surface. MVP is headless. | Out of scope for Phase 2. |
 
 ### Reply budget (hard contract)
 - **Max total reply: 320 characters** (2 SMS, Iridium 160-char frame × 2). Applies to EVERY command's reply, including `!post` confirmation, `!help`, `!cost`, etc.
@@ -145,10 +147,10 @@ Endorsed by the deep research report and consistent with the original engineerin
 | `TS_CONTEXT` | Per-IMEI rolling window (last 5 positions/messages) for narrative continuity | `ctx:<imei>` | 30d |
 | `TS_CACHE` | Geocode + weather cache | `geo:<lat:4,lon:4>` / `wx:<lat:2,lon:2>` | geo 24h / wx 1h |
 
-### Phased evolution (for alignment, not α)
-- **Phase 2:** Migrate `TS_CONTEXT` → Durable Objects (strong consistency for rapid message sequences). Add Cloudflare Queues for async retries.
-- **Phase 3:** Migrate `TS_LEDGER` → D1 (SQL analytics, per-user budgets, budget alerts). Add Analytics Engine.
-- **Phase 4+:** R2 + Image Resizing for photos (schema V4 media events).
+### Phased evolution (for alignment beyond α)
+- **Phase 2 — Extended commands.** Ship the eight α-deferred commands (see §2 deferrals table; plan: `plans/phase-2-extended-commands.md`; epic #98). Single-operator scope. Storage stays on KV; FieldLog is per-IMEI bounded list (P2-01). Address book is env-var JSON. No new transport. Active phase as of 2026-04-28.
+- **Phase 3 — Storage migration (DO + D1).** Migrate `TS_CONTEXT` and FieldLog → Durable Objects (strong consistency for rapid message sequences); migrate `TS_LEDGER` → D1 (SQL analytics, retention beyond a month, budget alerts). Add Cloudflare Queues for async retries. Epic #99.
+- **Phase 4+ — Media.** R2 + Image Resizing for photos (schema V4 media events). Filed conceptually as #125 (`!postimg`) for image generation; raw photo upload is post-v1.0.
 
 ### Tech stack (α)
 - **Runtime:** Cloudflare Workers


### PR DESCRIPTION
## Summary

Ground-truth refresh following the Phase 2 plan (#128) and the Production-readiness milestone close. Eliminates drift between the canonical docs (PRD, CLAUDE.md), the active plan, and the board's epic numbering. Refs #98.

## PRD edits

- **§1 Status** — flips from "Proceed to Phase 0" (stale since 2026-04-22) to Phase 2 active, with dates for each phase close and references to the close gates (#111, #126, #127).
- **§1 Non-goals** — corrected to list all eight deferred commands (was missing `!weather`; was inconsistent with §2's deferrals table).
- **§2 Deferrals table** — collapses the prior Phase 2/3/4 split into a single Phase 2 with internal sequencing, matching epic #98 and the plan. New "Phase 2 shape" column points each command at its P2-XX story.
- **§3 Phased evolution** — corrects mislabeled phases (was "Phase 2 = TS_CONTEXT → DO"; that's actually Phase 3 / epic #99). Now describes Phase 2 as extended commands and Phase 3 as the storage migration, matching the board.

## CLAUDE.md edits

- **Status block** — rewritten: Phase 0 done, Phase 1 done with #111 verified, Production-readiness closed (8/8), Phase 2 active, Phase 3 filed as #99.
- **Workflow → Active plan** — flipped from `phase-0-scaffolding.md` (long archived) to `phase-2-extended-commands.md`.
- **File-tree comment** — `commands.md` → `field-commands.md` (correct filename); refreshed `plans/` comment.

## Out of this PR (intentional)

- **Production-readiness milestone close** — closing the milestone is a `gh api` call (`PATCH .../milestones/3 -f state=closed`); lands directly via gh after this PR merges. State today: `0 open / 8 closed`, `state=open`.
- **Epic #98 + sub-issue #112–#119 body refreshes** — handled separately via `gh issue edit` after this PR merges so the issues link to the merged PRD/plan paths.
- **`docs/field-commands.md` structural rewrite** — that doc is stale beyond what #121 touched (still references OpenAI/Posthaven/Gmail). Scheduled as P2-12 in the Phase 2 plan; out of scope for this reconciliation PR.

## Test plan

- [ ] CI passes (no code change)
- [ ] Operator sanity-reads the PRD §2 deferrals table and the CLAUDE.md Status block; either signs off or files specific edits before the issue-body refreshes (next step) lock in the same wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)