### PR TITLE
feat(fieldlog): KV adapter for !drop / !brief (P2-01)

### DIFF
--- a/src/core/fieldlog.ts
+++ b/src/core/fieldlog.ts
@@ -1,0 +1,79 @@
+import type { Env } from "../env.js";
+import { getJSON, putJSON } from "../adapters/storage/kv.js";
+
+const FIELDLOG_TTL_SECONDS = 60 * 60 * 24 * 30;
+const MAX_ENTRIES = 100;
+
+/**
+ * One journal entry in the per-IMEI FieldLog. Written by `!drop` (P2-05);
+ * read + aggregated by `!brief` (P2-06). `source` is reserved so `!post`
+ * (or `!postimg`) titles can optionally fold into `!brief` later without a
+ * schema migration.
+ */
+export interface FieldLogEntry {
+  id: string;
+  ts: number;
+  lat?: number;
+  lon?: number;
+  note: string;
+  source: "drop" | "post";
+}
+
+export interface GetEntriesOptions {
+  /** Lower bound (inclusive) on `ts` in ms-epoch. */
+  since?: number;
+  /** Cap the result to the most-recent `limit` entries within the window. */
+  limit?: number;
+}
+
+/**
+ * Append an entry to the per-IMEI FieldLog under `fieldlog:<imei>`.
+ *
+ * Bounded at MAX_ENTRIES with FIFO eviction (oldest dropped first), so a
+ * long-running operator never blows past KV's per-key size limit.
+ *
+ * Idempotency: if an entry with the same `id` already exists, the call is a
+ * no-op. This matches the orchestrator's event-level idempotency key so
+ * Garmin retry storms (P1-13 `withCheckpoint` is the primary guard; this is
+ * defense-in-depth at the storage layer) do not produce duplicate journal
+ * entries.
+ *
+ * Read-modify-write per call. KV is eventually consistent; same caveat as
+ * context.ts and the ledger — at α volume (single operator, < 1 msg/sec) this
+ * doesn't bite. Phase 3 (#99) migrates to D1 for transactional updates.
+ */
+export async function appendEntry(env: Env, imei: string, entry: FieldLogEntry): Promise<void> {
+  const key = `fieldlog:${imei}`;
+  const existing = (await getJSON<FieldLogEntry[]>(env.TS_CONTEXT, key)) ?? [];
+
+  if (existing.some((e) => e.id === entry.id)) {
+    return;
+  }
+
+  const next = [...existing, entry].slice(-MAX_ENTRIES);
+  await putJSON(env.TS_CONTEXT, key, next, { expirationTtl: FIELDLOG_TTL_SECONDS });
+}
+
+/**
+ * Return entries for `imei` in chronological order (oldest first).
+ *
+ * `since` filters by `ts >= since`; `limit` caps to the most-recent N entries
+ * within that window (still returned oldest-first). A cold IMEI returns `[]`.
+ */
+export async function getEntries(
+  env: Env,
+  imei: string,
+  opts: GetEntriesOptions = {},
+): Promise<FieldLogEntry[]> {
+  const key = `fieldlog:${imei}`;
+  const stored = (await getJSON<FieldLogEntry[]>(env.TS_CONTEXT, key)) ?? [];
+
+  let filtered = stored;
+  if (opts.since !== undefined) {
+    filtered = filtered.filter((e) => e.ts >= opts.since!);
+  }
+  if (opts.limit !== undefined && filtered.length > opts.limit) {
+    filtered = filtered.slice(-opts.limit);
+  }
+  return filtered;
+}

--- a/tests/fieldlog.test.ts
+++ b/tests/fieldlog.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { appendEntry, getEntries, type FieldLogEntry } from "../src/core/fieldlog.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+
+beforeEach(() => {
+  env = makeTestEnv();
+});
+
+const entry = (overrides: Partial<FieldLogEntry> = {}): FieldLogEntry => ({
+  id: "idem-key-default",
+  ts: 1739802015000,
+  note: "saw a marmot",
+  source: "drop",
+  ...overrides,
+});
+
+const IMEI = "123456789012345";
+
+describe("getEntries — cold start", () => {
+  test("returns [] for an IMEI with no history", async () => {
+    expect(await getEntries(env, IMEI)).toEqual([]);
+  });
+});
+
+describe("appendEntry + getEntries — round-trip", () => {
+  test("appended entries are returned chronological (oldest first)", async () => {
+    await appendEntry(env, IMEI, entry({ id: "k1", ts: 1, note: "first" }));
+    await appendEntry(env, IMEI, entry({ id: "k2", ts: 2, note: "second" }));
+    await appendEntry(env, IMEI, entry({ id: "k3", ts: 3, note: "third" }));
+    const entries = await getEntries(env, IMEI);
+    expect(entries.map((e) => e.note)).toEqual(["first", "second", "third"]);
+  });
+
+  test("lat/lon are optional — entries without GPS round-trip cleanly", async () => {
+    await appendEntry(env, IMEI, entry({ id: "k1", ts: 10 }));
+    await appendEntry(env, IMEI, entry({ id: "k2", ts: 20, lat: 37.1682, lon: -118.5891 }));
+    const entries = await getEntries(env, IMEI);
+    expect(entries[0].lat).toBeUndefined();
+    expect(entries[0].lon).toBeUndefined();
+    expect(entries[1].lat).toBeCloseTo(37.1682, 4);
+    expect(entries[1].lon).toBeCloseTo(-118.5891, 4);
+  });
+
+  test("source field is preserved (drop vs post)", async () => {
+    await appendEntry(env, IMEI, entry({ id: "k1", ts: 1, source: "drop" }));
+    await appendEntry(env, IMEI, entry({ id: "k2", ts: 2, source: "post" }));
+    const entries = await getEntries(env, IMEI);
+    expect(entries.map((e) => e.source)).toEqual(["drop", "post"]);
+  });
+
+  test("per-IMEI isolation", async () => {
+    const other = "999999999999999";
+    await appendEntry(env, IMEI, entry({ id: "a", note: "alice" }));
+    await appendEntry(env, other, entry({ id: "b", note: "bob" }));
+    expect((await getEntries(env, IMEI)).map((e) => e.note)).toEqual(["alice"]);
+    expect((await getEntries(env, other)).map((e) => e.note)).toEqual(["bob"]);
+  });
+});
+
+describe("FIFO eviction at MAX_ENTRIES (100)", () => {
+  test("after 101 appends, the oldest is dropped and 100 remain", async () => {
+    for (let i = 1; i <= 101; i += 1) {
+      await appendEntry(env, IMEI, entry({ id: `k${i}`, ts: i, note: `entry-${i}` }));
+    }
+    const entries = await getEntries(env, IMEI);
+    expect(entries).toHaveLength(100);
+    // Oldest survivor is entry-2; entry-1 was evicted.
+    expect(entries[0].note).toBe("entry-2");
+    expect(entries[entries.length - 1].note).toBe("entry-101");
+  });
+});
+
+describe("idempotency — duplicate id is a no-op", () => {
+  test("re-appending the same id does not add a second entry", async () => {
+    await appendEntry(env, IMEI, entry({ id: "same-key", ts: 1, note: "first" }));
+    await appendEntry(env, IMEI, entry({ id: "same-key", ts: 1, note: "first" }));
+    await appendEntry(env, IMEI, entry({ id: "same-key", ts: 1, note: "first" }));
+    expect(await getEntries(env, IMEI)).toHaveLength(1);
+  });
+
+  test("a different id with the same content is a separate entry", async () => {
+    await appendEntry(env, IMEI, entry({ id: "k1", ts: 1, note: "saw a marmot" }));
+    await appendEntry(env, IMEI, entry({ id: "k2", ts: 2, note: "saw a marmot" }));
+    expect(await getEntries(env, IMEI)).toHaveLength(2);
+  });
+});
+
+describe("getEntries options — since + limit for !brief", () => {
+  beforeEach(async () => {
+    for (let i = 1; i <= 10; i += 1) {
+      await appendEntry(env, IMEI, entry({ id: `k${i}`, ts: i * 1000, note: `e${i}` }));
+    }
+  });
+
+  test("`since` filters to entries at-or-after the bound", async () => {
+    const out = await getEntries(env, IMEI, { since: 6000 });
+    expect(out.map((e) => e.note)).toEqual(["e6", "e7", "e8", "e9", "e10"]);
+  });
+
+  test("`limit` caps to the most-recent N (oldest-first)", async () => {
+    const out = await getEntries(env, IMEI, { limit: 3 });
+    expect(out.map((e) => e.note)).toEqual(["e8", "e9", "e10"]);
+  });
+
+  test("`since` + `limit` compose (filter, then cap)", async () => {
+    const out = await getEntries(env, IMEI, { since: 4000, limit: 2 });
+    expect(out.map((e) => e.note)).toEqual(["e9", "e10"]);
+  });
+});
+
+describe("KV semantics", () => {
+  test("each append writes fieldlog:<imei> with TTL 30 days, refreshed on every call", async () => {
+    const putSpy = vi.spyOn(env.TS_CONTEXT, "put");
+    await appendEntry(env, IMEI, entry({ id: "k1", ts: 1 }));
+    await appendEntry(env, IMEI, entry({ id: "k2", ts: 2 }));
+    expect(putSpy).toHaveBeenCalledTimes(2);
+    for (const call of putSpy.mock.calls) {
+      expect(String(call[0])).toBe(`fieldlog:${IMEI}`);
+      const opts = call[2] as { expirationTtl?: number } | undefined;
+      expect(opts?.expirationTtl).toBe(60 * 60 * 24 * 30);
+    }
+  });
+
+  test("idempotent replay does not write to KV", async () => {
+    await appendEntry(env, IMEI, entry({ id: "same", ts: 1 }));
+    const putSpy = vi.spyOn(env.TS_CONTEXT, "put");
+    await appendEntry(env, IMEI, entry({ id: "same", ts: 1 }));
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/core/fieldlog.ts` module — `appendEntry` + `getEntries` mirroring the `context.ts` rolling-window pattern, but tuned for journal-shaped data that backs `!drop` (P2-05 writer) and `!brief` (P2-06 reader).
- `FieldLogEntry { id, ts, lat?, lon?, note, source: 'drop' | 'post' }`. The `source` field is reserved so `!post` / `!postimg` titles can fold into `!brief` later without a schema migration.
- Bounded at **100 entries** per IMEI with FIFO eviction. Idempotency-keyed by entry `id` (orchestrator will thread its composite-event key in P2-05) — duplicate id is a true KV no-op, defense-in-depth on top of P1-13's `withCheckpoint`.
- `getEntries` returns chronological order (oldest first); `{ since, limit }` lets `!brief` ask for "last 24h, capped at N entries."
- 30-day TTL refreshed on every append, matching `context.ts` semantics.

Stored under `fieldlog:<imei>` in `TS_CONTEXT` to keep journal data isolated from the rolling-position context already in that namespace.

This is **PR 2 of 4** in the Phase 2 foundation sweep. The other three:
1. ✅ P2-02 grammar extension — #132
2. **P2-01 FieldLog (this PR)**
3. ⏳ P2-09 address-book config
4. ⏳ P2-17 image-gen adapter + prompt builder

Plan reference: `plans/phase-2-extended-commands.md` §P2-01.
Refs: #98.

## Acceptance criteria coverage

- [x] `appendEntry(env, imei, entry)` + `getEntries(env, imei, opts?)` exported.
- [x] `FieldLogEntry` shape matches plan: `{ id, ts, lat?, lon?, note, source: 'drop' | 'post' }`.
- [x] Bounded at MAX_ENTRIES = 100 per IMEI; FIFO eviction.
- [x] Concurrent-append safe via id-based no-op (`some(e => e.id === entry.id)`).
- [x] `getEntries` chronological (oldest first); `{ since, limit }` supported.
- [x] Vitest cases: append/read round-trip, eviction at the cap, concurrent-replay no-op, empty-FieldLog returns `[]` — 13 tests total covering all five plan-required cases plus `since`/`limit` composition.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm test` — 204/204 green; 13 new FieldLog tests; no regressions.
- [ ] Smoke-test once P2-05 lands: `!drop` 3 entries, peek the KV with `wrangler kv:key get fieldlog:<imei> --binding TS_CONTEXT`, confirm 3 entries chronological.

🤖 Generated with [Claude Code](https://claude.com/claude-code)