### PR TITLE
feat(addressbook): ADDRESS_BOOK_JSON config for !share / !blast (P2-09)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -40,3 +40,10 @@ RESEND_API_KEY=
 GITHUB_JOURNAL_TOKEN=
 GITHUB_JOURNAL_REPO=brockamer/trailscribe-journal
 GITHUB_JOURNAL_BRANCH=main
+
+# ---- Address book (Phase 2: !share / !blast) ----
+# JSON map of alias → email. Comma-separated values broadcast (used by !blast
+# via the conventional "all" alias). Empty string is valid (no aliases yet).
+# Single-line JSON; escape inner quotes when piping to `wrangler secret put`.
+# Example: {"aliases":{"home":"me@home.com","family":"a@x.com,b@y.com","all":"a@x.com,b@y.com,c@z.com"}}
+ADDRESS_BOOK_JSON=

--- a/src/core/addressbook.ts
+++ b/src/core/addressbook.ts
@@ -1,0 +1,81 @@
+import type { Env } from "../env.js";
+
+export interface AddressBook {
+  aliases: Record<string, string>;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Liberal email-shape check — parity with Resend's expectations, no MX lookup. */
+export function isValidEmail(addr: string): boolean {
+  return EMAIL_REGEX.test(addr.trim());
+}
+
+/**
+ * Parse and validate `ADDRESS_BOOK_JSON`. Empty string is valid (no aliases
+ * configured yet — `resolve` will throw on lookup). Throws with a readable
+ * message on malformed JSON, wrong shape, or non-email values.
+ *
+ * The "all" key may map to a comma-separated list of emails for `!blast`;
+ * other aliases are typically a single email but the same comma syntax works.
+ */
+export function parseAddressBookJson(raw: string): AddressBook {
+  if (raw.trim().length === 0) {
+    return { aliases: {} };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new Error(`ADDRESS_BOOK_JSON: not valid JSON (${detail})`, { cause: e });
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("ADDRESS_BOOK_JSON: must be a JSON object");
+  }
+  const aliases = (parsed as { aliases?: unknown }).aliases;
+  if (!aliases || typeof aliases !== "object" || Array.isArray(aliases)) {
+    throw new Error("ADDRESS_BOOK_JSON: must have shape { aliases: { name: email } }");
+  }
+
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(aliases as Record<string, unknown>)) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`ADDRESS_BOOK_JSON: alias '${name}' must be a non-empty string`);
+    }
+    const parts = splitAddresses(value);
+    if (parts.length === 0) {
+      throw new Error(`ADDRESS_BOOK_JSON: alias '${name}' has no addresses`);
+    }
+    for (const p of parts) {
+      if (!isValidEmail(p)) {
+        throw new Error(`ADDRESS_BOOK_JSON: alias '${name}' contains invalid email '${p}'`);
+      }
+    }
+    out[name] = value;
+  }
+  return { aliases: out };
+}
+
+/**
+ * Resolve an alias to one or more email addresses. Throws on unknown alias.
+ * Used by `!share` (P2-10) for a single recipient and `!blast` (P2-11) for
+ * the `all` group.
+ */
+export function resolve(env: Env, alias: string): string[] {
+  const book = parseAddressBookJson(env.ADDRESS_BOOK_JSON);
+  const value = book.aliases[alias];
+  if (value === undefined) {
+    throw new Error(`unknown alias: ${alias}`);
+  }
+  return splitAddresses(value);
+}
+
+function splitAddresses(value: string): string[] {
+  return value
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { parseAddressBookJson } from "./core/addressbook.js";
 
 /**
  * Worker `Env` binding shape. Mirrors `wrangler.toml` KV namespaces, vars, and secrets.
@@ -42,6 +43,7 @@ export interface Env {
   GITHUB_JOURNAL_TOKEN: string;
   GITHUB_JOURNAL_REPO: string;
   GITHUB_JOURNAL_BRANCH: string;
+  ADDRESS_BOOK_JSON: string;
 }
 
 /**
@@ -94,6 +96,19 @@ export const EnvSchema = z.object({
   GITHUB_JOURNAL_TOKEN: z.string().min(8),
   GITHUB_JOURNAL_REPO: z.string().regex(/^[\w.-]+\/[\w.-]+$/, "owner/repo format"),
   GITHUB_JOURNAL_BRANCH: z.string().min(1),
+  // Empty string = no aliases configured (resolve() will throw on lookup).
+  // Non-empty must parse via parseAddressBookJson — single source of truth for
+  // shape + email-shape validation, shared with src/core/addressbook.ts.
+  ADDRESS_BOOK_JSON: z.string().superRefine((s, ctx) => {
+    try {
+      parseAddressBookJson(s);
+    } catch (e) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }),
 });
 
 /**

--- a/tests/addressbook.test.ts
+++ b/tests/addressbook.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from "vitest";
+import {
+  parseAddressBookJson,
+  resolve,
+  isValidEmail,
+} from "../src/core/addressbook.js";
+import { parseEnv } from "../src/env.js";
+import { makeTestEnv } from "./helpers/env.js";
+
+describe("isValidEmail", () => {
+  test("accepts well-formed addresses", () => {
+    expect(isValidEmail("a@b.co")).toBe(true);
+    expect(isValidEmail("first.last+tag@sub.example.com")).toBe(true);
+    expect(isValidEmail("  spaces@trimmed.com  ")).toBe(true);
+  });
+
+  test("rejects malformed addresses", () => {
+    expect(isValidEmail("nope")).toBe(false);
+    expect(isValidEmail("noat.example.com")).toBe(false);
+    expect(isValidEmail("a@b")).toBe(false);
+    expect(isValidEmail("@b.com")).toBe(false);
+    expect(isValidEmail("a@.com")).toBe(false);
+  });
+});
+
+describe("parseAddressBookJson — empty / no aliases configured", () => {
+  test("empty string returns an empty alias map (valid)", () => {
+    expect(parseAddressBookJson("")).toEqual({ aliases: {} });
+  });
+
+  test("whitespace-only is treated as empty", () => {
+    expect(parseAddressBookJson("   \n  ")).toEqual({ aliases: {} });
+  });
+});
+
+describe("parseAddressBookJson — happy path", () => {
+  test("parses single-email aliases", () => {
+    const raw = JSON.stringify({
+      aliases: { home: "me@home.com", editor: "ed@magazine.com" },
+    });
+    expect(parseAddressBookJson(raw)).toEqual({
+      aliases: { home: "me@home.com", editor: "ed@magazine.com" },
+    });
+  });
+
+  test("parses comma-separated 'all' alias for !blast", () => {
+    const raw = JSON.stringify({ aliases: { all: "a@x.com,b@y.com,c@z.com" } });
+    expect(parseAddressBookJson(raw).aliases.all).toBe("a@x.com,b@y.com,c@z.com");
+  });
+});
+
+describe("parseAddressBookJson — rejection paths", () => {
+  test("malformed JSON throws", () => {
+    expect(() => parseAddressBookJson("{aliases:")).toThrow(/not valid JSON/);
+  });
+
+  test("non-object root throws", () => {
+    expect(() => parseAddressBookJson('"a string"')).toThrow(/JSON object/);
+    expect(() => parseAddressBookJson("[]")).toThrow(/JSON object/);
+    expect(() => parseAddressBookJson("null")).toThrow(/JSON object/);
+  });
+
+  test("missing aliases key throws", () => {
+    expect(() => parseAddressBookJson("{}")).toThrow(/aliases/);
+  });
+
+  test("aliases is not an object", () => {
+    expect(() => parseAddressBookJson('{"aliases":"home"}')).toThrow(/aliases/);
+    expect(() => parseAddressBookJson('{"aliases":[]}')).toThrow(/aliases/);
+  });
+
+  test("alias value is non-string", () => {
+    expect(() =>
+      parseAddressBookJson('{"aliases":{"home":42}}'),
+    ).toThrow(/alias 'home'/);
+  });
+
+  test("alias value is empty string", () => {
+    expect(() =>
+      parseAddressBookJson('{"aliases":{"home":""}}'),
+    ).toThrow(/alias 'home'/);
+  });
+
+  test("alias value contains an invalid email", () => {
+    expect(() =>
+      parseAddressBookJson('{"aliases":{"home":"not-an-email"}}'),
+    ).toThrow(/invalid email/);
+  });
+
+  test("comma-list with one bad email rejects the whole alias", () => {
+    expect(() =>
+      parseAddressBookJson('{"aliases":{"all":"a@x.com,bad,c@z.com"}}'),
+    ).toThrow(/invalid email/);
+  });
+});
+
+describe("resolve — alias lookup", () => {
+  test("single-email alias returns a one-element list", () => {
+    const env = makeTestEnv({
+      ADDRESS_BOOK_JSON: JSON.stringify({ aliases: { home: "me@home.com" } }),
+    });
+    expect(resolve(env, "home")).toEqual(["me@home.com"]);
+  });
+
+  test("'all' alias returns the comma-list as separate addresses", () => {
+    const env = makeTestEnv({
+      ADDRESS_BOOK_JSON: JSON.stringify({ aliases: { all: "a@x.com,b@y.com,c@z.com" } }),
+    });
+    expect(resolve(env, "all")).toEqual(["a@x.com", "b@y.com", "c@z.com"]);
+  });
+
+  test("unknown alias throws", () => {
+    const env = makeTestEnv({
+      ADDRESS_BOOK_JSON: JSON.stringify({ aliases: { home: "me@home.com" } }),
+    });
+    expect(() => resolve(env, "stranger")).toThrow(/unknown alias: stranger/);
+  });
+
+  test("empty address book throws on any lookup", () => {
+    const env = makeTestEnv({ ADDRESS_BOOK_JSON: "" });
+    expect(() => resolve(env, "home")).toThrow(/unknown alias/);
+  });
+});
+
+describe("env validation — ADDRESS_BOOK_JSON refinement", () => {
+  test("empty string is accepted", () => {
+    const env = makeTestEnv({ ADDRESS_BOOK_JSON: "" });
+    expect(() => parseEnv(env)).not.toThrow();
+  });
+
+  test("well-formed JSON is accepted", () => {
+    const env = makeTestEnv({
+      ADDRESS_BOOK_JSON: JSON.stringify({ aliases: { home: "me@home.com" } }),
+    });
+    expect(() => parseEnv(env)).not.toThrow();
+  });
+
+  test("malformed JSON fails parseEnv", () => {
+    const env = makeTestEnv({ ADDRESS_BOOK_JSON: "{not json" });
+    expect(() => parseEnv(env)).toThrow(/ADDRESS_BOOK_JSON/);
+  });
+
+  test("non-email value fails parseEnv", () => {
+    const env = makeTestEnv({
+      ADDRESS_BOOK_JSON: JSON.stringify({ aliases: { home: "nope" } }),
+    });
+    expect(() => parseEnv(env)).toThrow(/ADDRESS_BOOK_JSON/);
+  });
+});

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -89,6 +89,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_JOURNAL_TOKEN: "ghp_test_abcd",
     GITHUB_JOURNAL_REPO: "brockamer/trailscribe-journal",
     GITHUB_JOURNAL_BRANCH: "main",
+    ADDRESS_BOOK_JSON: "",
   };
   return { ...base, ...overrides };
 }


### PR DESCRIPTION
## Summary

- New `src/core/addressbook.ts` exports `parseAddressBookJson` (validation: shape + email-shape) and `resolve(env, alias) → string[]` for the upcoming `!share` (P2-10) and `!blast` (P2-11) handlers.
- `ADDRESS_BOOK_JSON` env var added to `Env` + zod schema. Empty is valid (no aliases configured); non-empty must match `{ aliases: Record<string, string> }` with email-shaped values. Comma-separated values support the `all` group used by `!blast`.
- The zod schema delegates to `parseAddressBookJson` via `superRefine` — single source of truth, so `parseEnv()` catches misconfigurations the same way at test/deploy time.
- `.dev.vars.example` documents the alias schema with a `wrangler secret put` quoting note. Test helper picks up an empty-string default so all existing tests stay green.

This is **PR 3 of 4** in the Phase 2 foundation sweep:
1. ✅ P2-02 grammar extension — #132
2. ✅ P2-01 FieldLog — #133
3. **P2-09 address book (this PR)**
4. ⏳ P2-17 image-gen adapter + prompt builder

Plan reference: `plans/phase-2-extended-commands.md` §P2-09 (resolved env-var JSON, 2026-04-28).
Refs: #98.

## Acceptance criteria coverage

- [x] `ADDRESS_BOOK_JSON` validated by zod in `src/env.ts`.
- [x] `src/core/addressbook.ts` exports `resolve(env, alias) → string[]` (returns one or more emails; throws on unknown alias).
- [x] Validation rejects malformed JSON or non-email values with a typed Error and clear message. (Plan called for `EnvValidationError`; Phase 1's pattern is plain `Error` from `parseEnv` — kept consistent rather than introducing a single-use error class.)
- [x] Wrangler secret + `.dev.vars.example` documented.
- [x] CLAUDE.md secrets list already mentions `ADDRESS_BOOK_JSON` (added when the plan was filed in #128) — no further edit needed.
- [x] Vitest cases: known-alias resolve, `all` resolve to list, unknown alias throws, malformed JSON fails env validation — 22 tests total.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm test` — 213/213 green; 22 new addressbook tests; no regressions.
- [ ] After merge: set the secret on staging — `echo -n '{"aliases":{...}}' | wrangler secret put ADDRESS_BOOK_JSON --env staging` (per memory `feedback_secret_pasting.md`, use `echo -n` to strip trailing newlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)