### PR TITLE
feat(image-gen): Replicate adapter + prompt builder + image ledger axis (P2-17)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -47,3 +47,9 @@ GITHUB_JOURNAL_BRANCH=main
 # Single-line JSON; escape inner quotes when piping to `wrangler secret put`.
 # Example: {"aliases":{"home":"me@home.com","family":"a@x.com,b@y.com","all":"a@x.com,b@y.com,c@z.com"}}
 ADDRESS_BOOK_JSON=
+
+# ---- Image generation (Phase 2: !postimg via Replicate Flux schnell) ----
+# Replicate API token from https://replicate.com/account/api-tokens.
+# Same `echo -n "<token>" | wrangler secret put IMAGE_API_KEY --env <env>` rule
+# as other secrets — strip trailing newlines.
+IMAGE_API_KEY=

--- a/src/adapters/ai/replicate.ts
+++ b/src/adapters/ai/replicate.ts
@@ -1,0 +1,161 @@
+import type { Env } from "../../env.js";
+
+/**
+ * Replicate predictions API response (subset we consume). The full schema is
+ * documented at https://replicate.com/docs/reference/http#predictions.create.
+ */
+interface ReplicatePrediction {
+  id: string;
+  status: "starting" | "processing" | "succeeded" | "failed" | "canceled";
+  output?: string | string[] | null;
+  error?: string | null;
+}
+
+export interface GenerateImageArgs {
+  prompt: string;
+  /** Aspect ratio passed to model `input.aspect_ratio` when supported. */
+  aspectRatio?: "1:1" | "16:9" | "9:16" | "4:3" | "3:4";
+  env: Env;
+  /** Override `fetch` for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface GenerateImageResult {
+  bytes: ArrayBuffer;
+  mimeType: string;
+  model: string;
+  costUsd: number;
+}
+
+/**
+ * Typed error from the image-gen provider. `status` is the HTTP status (0 for
+ * non-HTTP failures); `providerResponse` carries the raw body for diagnostics
+ * via the orchestrator's structured log.
+ */
+export class ImageGenError extends Error {
+  public readonly status: number;
+  public readonly providerResponse?: string;
+
+  constructor(opts: { status: number; message: string; providerResponse?: string }) {
+    super(opts.message);
+    this.name = "ImageGenError";
+    this.status = opts.status;
+    this.providerResponse = opts.providerResponse;
+  }
+}
+
+/**
+ * Generate one image via the configured provider (Replicate Flux schnell for
+ * the first cut — locked by P2-17 to keep `!postimg` under the PRD §7 $0.05
+ * ceiling without a premium-class exception).
+ *
+ * Uses Replicate's `Prefer: wait` header for synchronous predictions — Flux
+ * schnell completes well under Workers' subrequest budget. If a future model
+ * needs longer than `wait` allows, this adapter must move to poll-mode and
+ * the orchestrator's `withCheckpoint` window has to lengthen accordingly.
+ *
+ * Returns the image bytes + cost; throws `ImageGenError` on any failure mode
+ * (HTTP error, non-succeeded prediction, output URL fetch failure). Caller
+ * (`!postimg` handler in P2-18) catches and falls back to text-only `!post`.
+ */
+export async function generateImage(args: GenerateImageArgs): Promise<GenerateImageResult> {
+  const { prompt, aspectRatio, env } = args;
+  const httpFetch = args.fetchImpl ?? fetch;
+
+  if (env.IMAGE_PROVIDER !== "replicate") {
+    throw new ImageGenError({
+      status: 0,
+      message: `unsupported IMAGE_PROVIDER: ${env.IMAGE_PROVIDER}`,
+    });
+  }
+
+  // Replicate's "predictions by model" endpoint resolves the latest version
+  // automatically — operator doesn't need to pin a version hash for first-cut.
+  const url = `https://api.replicate.com/v1/models/${env.IMAGE_MODEL}/predictions`;
+  const input: Record<string, unknown> = { prompt };
+  if (aspectRatio !== undefined) input.aspect_ratio = aspectRatio;
+
+  let res: Response;
+  try {
+    res = await httpFetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.IMAGE_API_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "wait",
+      },
+      body: JSON.stringify({ input }),
+    });
+  } catch (e) {
+    throw new ImageGenError({
+      status: 0,
+      message: `network error contacting Replicate: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  if (!res.ok) {
+    const body = await safeText(res);
+    throw new ImageGenError({
+      status: res.status,
+      message: `Replicate prediction failed: HTTP ${res.status}`,
+      providerResponse: body,
+    });
+  }
+
+  const prediction = (await res.json()) as ReplicatePrediction;
+  if (prediction.status !== "succeeded") {
+    throw new ImageGenError({
+      status: 0,
+      message: `Replicate prediction did not succeed: status=${prediction.status}${prediction.error ? `, error=${prediction.error}` : ""}`,
+      providerResponse: JSON.stringify(prediction),
+    });
+  }
+
+  const outputUrl = pickOutputUrl(prediction.output);
+  if (outputUrl === undefined) {
+    throw new ImageGenError({
+      status: 0,
+      message: "Replicate output is empty or not a URL",
+      providerResponse: JSON.stringify(prediction),
+    });
+  }
+
+  let imageRes: Response;
+  try {
+    imageRes = await httpFetch(outputUrl);
+  } catch (e) {
+    throw new ImageGenError({
+      status: 0,
+      message: `network error fetching generated image: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+  if (!imageRes.ok) {
+    throw new ImageGenError({
+      status: imageRes.status,
+      message: `Failed to fetch generated image bytes: HTTP ${imageRes.status}`,
+    });
+  }
+
+  const bytes = await imageRes.arrayBuffer();
+  const mimeType = imageRes.headers.get("content-type") ?? "image/webp";
+  const costUsd = Number.parseFloat(env.IMAGE_COST_PER_CALL_USD) || 0;
+
+  return { bytes, mimeType, model: env.IMAGE_MODEL, costUsd };
+}
+
+function pickOutputUrl(output: string | string[] | null | undefined): string | undefined {
+  if (!output) return undefined;
+  if (typeof output === "string") return output;
+  if (Array.isArray(output) && output.length > 0 && typeof output[0] === "string") {
+    return output[0];
+  }
+  return undefined;
+}
+
+async function safeText(res: Response): Promise<string | undefined> {
+  try {
+    return await res.text();
+  } catch {
+    return undefined;
+  }
+}

--- a/src/core/imageprompt.ts
+++ b/src/core/imageprompt.ts
@@ -1,0 +1,60 @@
+export interface ImagePromptInputs {
+  caption: string;
+  /** Reverse-geocoded place name (no specific landmark naming required). */
+  place?: string;
+  lat?: number;
+  lon?: number;
+  altitudeM?: number;
+  /** Free-form local time string, e.g. "07:42 — early morning". */
+  localTime?: string;
+  /** Free-form weather summary, e.g. "scattered clouds, 9C, light wind". */
+  weather?: string;
+}
+
+const REALISM_GUARDS = [
+  "Realistic, plausible scene grounded in the telemetry above.",
+  "Lighting and shadows match the local time of day.",
+  "No text, captions, watermarks, signs, or readable lettering anywhere in the image.",
+  "Do not invent or label specific named landmarks unless explicitly stated above.",
+];
+
+/**
+ * Build a deterministic, paragraph-style prompt grounding the image in the
+ * device telemetry. Inputs are described in the order Place → Coords →
+ * Altitude → Time → Weather so the output is stable across runs (the
+ * snapshot tests assert exact strings, since prompt drift = image drift).
+ *
+ * Optional axes are omitted gracefully — a no-GPS-fix `!postimg` should still
+ * produce a usable prompt off the caption + (maybe) weather + (maybe) time.
+ *
+ * Realism guards (no-text, no-fake-landmarks, lighting-matches-time) are
+ * always appended; they encode the constraints from #125's body and are the
+ * difference between a journal-illustration prompt and a generic stock-image
+ * prompt.
+ */
+export function buildImagePrompt(inputs: ImagePromptInputs): string {
+  const parts: string[] = [`Photographic field journal illustration: ${inputs.caption.trim()}.`];
+
+  if (inputs.place !== undefined && inputs.place.length > 0) {
+    parts.push(`Location: ${inputs.place}.`);
+  }
+  if (inputs.lat !== undefined && inputs.lon !== undefined) {
+    parts.push(`Coordinates: ${formatCoord(inputs.lat)}, ${formatCoord(inputs.lon)}.`);
+  }
+  if (inputs.altitudeM !== undefined) {
+    parts.push(`Altitude: ${Math.round(inputs.altitudeM)} m.`);
+  }
+  if (inputs.localTime !== undefined && inputs.localTime.length > 0) {
+    parts.push(`Local time: ${inputs.localTime}.`);
+  }
+  if (inputs.weather !== undefined && inputs.weather.length > 0) {
+    parts.push(`Weather: ${inputs.weather}.`);
+  }
+
+  parts.push(...REALISM_GUARDS);
+  return parts.join(" ");
+}
+
+function formatCoord(n: number): string {
+  return n.toFixed(4);
+}

--- a/src/core/ledger.ts
+++ b/src/core/ledger.ts
@@ -23,6 +23,21 @@ export interface LedgerSnapshot {
   usd_cost: number;
   by_command: Record<string, { requests: number; usd_cost: number }>;
   last_update_ms: number;
+  /**
+   * Image-gen aggregates (P2-17). Optional for backwards compat with
+   * snapshots written before P2-17 deployed — readers default to 0 via `?? 0`.
+   * `recordImageTransaction` updates only these fields; existing text
+   * accounting (`requests`, `usd_cost`, `by_command`) is untouched.
+   */
+  image_requests?: number;
+  image_usd_cost?: number;
+}
+
+/** Image-gen ledger entry — usdCost is provider-quoted, no token math. */
+export interface ImageLedgerEntry {
+  command: string;
+  usdCost: number;
+  env: Env;
 }
 
 /**
@@ -45,6 +60,37 @@ export async function recordTransaction(entry: LedgerEntry): Promise<{ usd_cost:
   await applyToRollup(entry.env, `ledger:${yyyymm}`, yyyymm, entry, usd_cost, now);
   try {
     await applyToRollup(entry.env, `ledger:${yyyymmdd}`, yyyymmdd, entry, usd_cost, now, {
+      expirationTtl: DAILY_TTL_SECONDS,
+    });
+  } catch (e) {
+    log({
+      event: "ledger_daily_write_failed",
+      level: "warn",
+      period: yyyymmdd,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  return { usd_cost };
+}
+
+/**
+ * Record one image-gen transaction (P2-17). Writes to the same monthly +
+ * daily ledger keys but updates only the image aggregates, leaving text
+ * fields alone so existing `!cost` semantics are unaffected. P2-18's `!cost`
+ * formatter consumes both axes for the breakout reply.
+ */
+export async function recordImageTransaction(
+  entry: ImageLedgerEntry,
+): Promise<{ usd_cost: number }> {
+  const usd_cost = entry.usdCost;
+  const now = Date.now();
+  const yyyymm = formatMonth(now);
+  const yyyymmdd = formatDay(now);
+
+  await applyImageToRollup(entry.env, `ledger:${yyyymm}`, yyyymm, usd_cost, now);
+  try {
+    await applyImageToRollup(entry.env, `ledger:${yyyymmdd}`, yyyymmdd, usd_cost, now, {
       expirationTtl: DAILY_TTL_SECONDS,
     });
   } catch (e) {
@@ -83,6 +129,25 @@ async function applyToRollup(
   await putJSON(env.TS_LEDGER, key, updated, opts);
 }
 
+async function applyImageToRollup(
+  env: Env,
+  key: string,
+  period: string,
+  usd_cost: number,
+  now: number,
+  opts?: { expirationTtl?: number },
+): Promise<void> {
+  const existing = await getJSON<LedgerSnapshot>(env.TS_LEDGER, key);
+  const base = existing ?? emptySnapshot(period);
+  const updated: LedgerSnapshot = {
+    ...base,
+    image_requests: (base.image_requests ?? 0) + 1,
+    image_usd_cost: (base.image_usd_cost ?? 0) + usd_cost,
+    last_update_ms: now,
+  };
+  await putJSON(env.TS_LEDGER, key, updated, opts);
+}
+
 async function readRollup(env: Env, key: string, period: string): Promise<LedgerSnapshot> {
   const existing = await getJSON<LedgerSnapshot>(env.TS_LEDGER, key);
   return existing ?? emptySnapshot(period);
@@ -108,6 +173,9 @@ function mergeEntry(
     usd_cost: snap.usd_cost + usd_cost,
     by_command: byCmd,
     last_update_ms: now,
+    // Preserve image aggregates across text writes (P2-17 backwards compat).
+    image_requests: snap.image_requests,
+    image_usd_cost: snap.image_usd_cost,
   };
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -31,6 +31,9 @@ export interface Env {
   RESEND_FROM_NAME: string;
   JOURNAL_POST_PATH_TEMPLATE: string;
   JOURNAL_URL_TEMPLATE: string;
+  IMAGE_PROVIDER: string;
+  IMAGE_MODEL: string;
+  IMAGE_COST_PER_CALL_USD: string;
 
   // Secrets (Wrangler Secrets)
   GARMIN_INBOUND_TOKEN: string;
@@ -44,6 +47,7 @@ export interface Env {
   GITHUB_JOURNAL_REPO: string;
   GITHUB_JOURNAL_BRANCH: string;
   ADDRESS_BOOK_JSON: string;
+  IMAGE_API_KEY: string;
 }
 
 /**
@@ -85,6 +89,9 @@ export const EnvSchema = z.object({
   RESEND_FROM_NAME: z.string().min(1),
   JOURNAL_POST_PATH_TEMPLATE: z.string().min(1),
   JOURNAL_URL_TEMPLATE: z.string().min(1),
+  IMAGE_PROVIDER: z.enum(["replicate"]),
+  IMAGE_MODEL: z.string().min(1),
+  IMAGE_COST_PER_CALL_USD: z.string(),
 
   GARMIN_INBOUND_TOKEN: z.string().min(16),
   GARMIN_IPC_INBOUND_API_KEY: z.string().min(8),
@@ -109,6 +116,7 @@ export const EnvSchema = z.object({
       });
     }
   }),
+  IMAGE_API_KEY: z.string().min(8),
 });
 
 /**

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -78,6 +78,9 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     RESEND_FROM_NAME: "TrailScribe",
     JOURNAL_POST_PATH_TEMPLATE: "_posts/{yyyy}-{mm}-{dd}-{slug}.md",
     JOURNAL_URL_TEMPLATE: "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html",
+    IMAGE_PROVIDER: "replicate",
+    IMAGE_MODEL: "black-forest-labs/flux-schnell",
+    IMAGE_COST_PER_CALL_USD: "0.003",
 
     GARMIN_INBOUND_TOKEN: "test-bearer-token-abcdef0123456789",
     GARMIN_IPC_INBOUND_API_KEY: "test-api-key-abcd",
@@ -90,6 +93,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_JOURNAL_REPO: "brockamer/trailscribe-journal",
     GITHUB_JOURNAL_BRANCH: "main",
     ADDRESS_BOOK_JSON: "",
+    IMAGE_API_KEY: "test-image-api-key",
   };
   return { ...base, ...overrides };
 }

--- a/tests/imageprompt.test.ts
+++ b/tests/imageprompt.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "vitest";
+import { buildImagePrompt } from "../src/core/imageprompt.js";
+
+describe("buildImagePrompt — determinism", () => {
+  test("same inputs produce identical strings", () => {
+    const inputs = {
+      caption: "dawn light on the cirque",
+      place: "Sierra Nevada, CA",
+      lat: 37.1682,
+      lon: -118.5891,
+      altitudeM: 3810,
+      localTime: "07:42 — early morning",
+      weather: "scattered clouds, 9C, light wind",
+    };
+    expect(buildImagePrompt(inputs)).toBe(buildImagePrompt(inputs));
+  });
+});
+
+describe("buildImagePrompt — telemetry profile snapshots", () => {
+  test("alpine profile (full telemetry)", () => {
+    expect(
+      buildImagePrompt({
+        caption: "dawn light on the cirque",
+        place: "Sierra Nevada, CA",
+        lat: 37.1682,
+        lon: -118.5891,
+        altitudeM: 3810,
+        localTime: "07:42 — early morning",
+        weather: "scattered clouds, 9C, light wind",
+      }),
+    ).toMatchInlineSnapshot(
+      `"Photographic field journal illustration: dawn light on the cirque. Location: Sierra Nevada, CA. Coordinates: 37.1682, -118.5891. Altitude: 3810 m. Local time: 07:42 — early morning. Weather: scattered clouds, 9C, light wind. Realistic, plausible scene grounded in the telemetry above. Lighting and shadows match the local time of day. No text, captions, watermarks, signs, or readable lettering anywhere in the image. Do not invent or label specific named landmarks unless explicitly stated above."`,
+    );
+  });
+
+  test("coastal-bluff profile (no altitude)", () => {
+    expect(
+      buildImagePrompt({
+        caption: "fog rolling in over the headland",
+        place: "Marin Headlands, CA",
+        lat: 37.8324,
+        lon: -122.5,
+        localTime: "16:10 — late afternoon",
+        weather: "marine layer, 14C",
+      }),
+    ).toMatchInlineSnapshot(
+      `"Photographic field journal illustration: fog rolling in over the headland. Location: Marin Headlands, CA. Coordinates: 37.8324, -122.5000. Local time: 16:10 — late afternoon. Weather: marine layer, 14C. Realistic, plausible scene grounded in the telemetry above. Lighting and shadows match the local time of day. No text, captions, watermarks, signs, or readable lettering anywhere in the image. Do not invent or label specific named landmarks unless explicitly stated above."`,
+    );
+  });
+
+  test("desert-flank profile (caption + telemetry only, no place)", () => {
+    expect(
+      buildImagePrompt({
+        caption: "Joshua trees at golden hour",
+        lat: 33.8734,
+        lon: -115.9009,
+        altitudeM: 1100,
+        localTime: "18:45 — golden hour",
+        weather: "clear, 28C, calm",
+      }),
+    ).toMatchInlineSnapshot(
+      `"Photographic field journal illustration: Joshua trees at golden hour. Coordinates: 33.8734, -115.9009. Altitude: 1100 m. Local time: 18:45 — golden hour. Weather: clear, 28C, calm. Realistic, plausible scene grounded in the telemetry above. Lighting and shadows match the local time of day. No text, captions, watermarks, signs, or readable lettering anywhere in the image. Do not invent or label specific named landmarks unless explicitly stated above."`,
+    );
+  });
+});
+
+describe("buildImagePrompt — graceful omission", () => {
+  test("caption-only (no GPS, no enrichment)", () => {
+    const out = buildImagePrompt({ caption: "test caption" });
+    expect(out).toContain("Photographic field journal illustration: test caption.");
+    expect(out).not.toContain("Coordinates:");
+    expect(out).not.toContain("Altitude:");
+    expect(out).not.toContain("Location:");
+    expect(out).not.toContain("Local time:");
+    expect(out).not.toContain("Weather:");
+    expect(out).toContain("Realistic, plausible scene");
+    expect(out).toContain("No text, captions, watermarks");
+  });
+
+  test("empty optional strings are treated as absent", () => {
+    const out = buildImagePrompt({
+      caption: "x",
+      place: "",
+      localTime: "",
+      weather: "",
+    });
+    expect(out).not.toContain("Location:");
+    expect(out).not.toContain("Local time:");
+    expect(out).not.toContain("Weather:");
+  });
+
+  test("lat without lon (or vice versa) omits coordinates", () => {
+    const onlyLat = buildImagePrompt({ caption: "x", lat: 37.0 });
+    expect(onlyLat).not.toContain("Coordinates:");
+    const onlyLon = buildImagePrompt({ caption: "x", lon: -118.0 });
+    expect(onlyLon).not.toContain("Coordinates:");
+  });
+
+  test("realism guards always present, regardless of telemetry availability", () => {
+    const minimal = buildImagePrompt({ caption: "x" });
+    expect(minimal).toContain("No text, captions, watermarks");
+    expect(minimal).toContain("Do not invent or label specific named landmarks");
+    expect(minimal).toContain("Lighting and shadows match the local time");
+  });
+});

--- a/tests/ledger.test.ts
+++ b/tests/ledger.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
 import {
   recordTransaction,
+  recordImageTransaction,
   monthlyTotals,
   dailyTotals,
   type LedgerSnapshot,
 } from "../src/core/ledger.js";
+import { putJSON } from "../src/adapters/storage/kv.js";
 import { makeTestEnv } from "./helpers/env.js";
 import type { Env } from "../src/env.js";
 
@@ -173,6 +175,20 @@ describe("recordTransaction — KV semantics", () => {
     expect(totals.usd_cost).toBe(0);
   });
 
+  test("monthly snapshot returns image fields as 0 when never written (backwards compat)", async () => {
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+      env,
+    });
+    const monthly = await monthlyTotals(env);
+    expect(monthly.image_requests).toBeUndefined();
+    expect(monthly.image_usd_cost).toBeUndefined();
+    // Reader pattern (used by !cost): coalesce undefined → 0
+    expect(monthly.image_requests ?? 0).toBe(0);
+    expect(monthly.image_usd_cost ?? 0).toBe(0);
+  });
+
   test("daily-write failure does not throw; monthly write still succeeds", async () => {
     let dailyAttempts = 0;
     const realPut = env.TS_LEDGER.put.bind(env.TS_LEDGER);
@@ -198,5 +214,80 @@ describe("recordTransaction — KV semantics", () => {
 
     const events = loggedEvents().map((e) => e.event);
     expect(events).toContain("ledger_daily_write_failed");
+  });
+});
+
+describe("recordImageTransaction — image-gen aggregates (P2-17)", () => {
+  test("first image write seeds image_requests=1 and image_usd_cost=cost", async () => {
+    await recordImageTransaction({ command: "postimg", usdCost: 0.003, env });
+    const monthly = await monthlyTotals(env);
+    expect(monthly.image_requests).toBe(1);
+    expect(monthly.image_usd_cost).toBeCloseTo(0.003, 6);
+  });
+
+  test("two image writes accumulate", async () => {
+    await recordImageTransaction({ command: "postimg", usdCost: 0.003, env });
+    await recordImageTransaction({ command: "postimg", usdCost: 0.005, env });
+    const monthly = await monthlyTotals(env);
+    expect(monthly.image_requests).toBe(2);
+    expect(monthly.image_usd_cost).toBeCloseTo(0.008, 6);
+  });
+
+  test("image writes do NOT touch text fields (requests, usd_cost, by_command)", async () => {
+    await recordImageTransaction({ command: "postimg", usdCost: 0.003, env });
+    const monthly = await monthlyTotals(env);
+    expect(monthly.requests).toBe(0);
+    expect(monthly.usd_cost).toBe(0);
+    expect(monthly.prompt_tokens).toBe(0);
+    expect(monthly.completion_tokens).toBe(0);
+    expect(monthly.by_command).toEqual({});
+  });
+
+  test("text writes preserve existing image aggregates (mergeEntry carry-over)", async () => {
+    await recordImageTransaction({ command: "postimg", usdCost: 0.003, env });
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
+      env,
+    });
+    const monthly = await monthlyTotals(env);
+    expect(monthly.image_requests).toBe(1);
+    expect(monthly.image_usd_cost).toBeCloseTo(0.003, 6);
+    expect(monthly.requests).toBe(1);
+    expect(monthly.by_command.post.requests).toBe(1);
+  });
+
+  test("daily snapshot also receives the image write", async () => {
+    await recordImageTransaction({ command: "postimg", usdCost: 0.003, env });
+    const daily = await dailyTotals(env);
+    expect(daily.image_requests).toBe(1);
+    expect(daily.image_usd_cost).toBeCloseTo(0.003, 6);
+  });
+
+  test("a pre-P2-17 snapshot (no image fields) gets image fields on first image write", async () => {
+    // Simulate an existing snapshot written by Phase 1 ledger code, which
+    // never set image_requests / image_usd_cost.
+    const yyyymm = new Date().toISOString().slice(0, 7);
+    const legacy: LedgerSnapshot = {
+      period: yyyymm,
+      requests: 5,
+      prompt_tokens: 200,
+      completion_tokens: 100,
+      usd_cost: 0.42,
+      by_command: { post: { requests: 5, usd_cost: 0.42 } },
+      last_update_ms: Date.now() - 1000,
+    };
+    await putJSON(env.TS_LEDGER, `ledger:${yyyymm}`, legacy);
+
+    await recordImageTransaction({ command: "postimg", usdCost: 0.003, env });
+
+    const monthly = await monthlyTotals(env);
+    // Image aggregates seeded
+    expect(monthly.image_requests).toBe(1);
+    expect(monthly.image_usd_cost).toBeCloseTo(0.003, 6);
+    // Legacy text aggregates untouched
+    expect(monthly.requests).toBe(5);
+    expect(monthly.usd_cost).toBeCloseTo(0.42, 4);
+    expect(monthly.by_command.post.requests).toBe(5);
   });
 });

--- a/tests/replicate.test.ts
+++ b/tests/replicate.test.ts
@@ -1,0 +1,177 @@
+import { describe, test, expect, beforeEach, vi, type Mock } from "vitest";
+import { generateImage, ImageGenError } from "../src/adapters/ai/replicate.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+
+let env: Env;
+let fetchImpl: Mock<typeof fetch>;
+
+beforeEach(() => {
+  env = makeTestEnv();
+  fetchImpl = vi.fn();
+});
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+
+function predictionResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function imageResponse(bytes: ArrayBuffer, mimeType = "image/png"): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: { "content-type": mimeType },
+  });
+}
+
+describe("generateImage — happy path", () => {
+  test("POSTs to the model predictions endpoint with Prefer: wait, then fetches the output URL", async () => {
+    fetchImpl
+      .mockResolvedValueOnce(
+        predictionResponse({
+          id: "pred-1",
+          status: "succeeded",
+          output: ["https://replicate.delivery/foo.png"],
+        }),
+      )
+      .mockResolvedValueOnce(imageResponse(PNG_BYTES, "image/png"));
+
+    const result = await generateImage({
+      prompt: "alpine cirque",
+      aspectRatio: "16:9",
+      env,
+      fetchImpl,
+    });
+
+    expect(result.bytes.byteLength).toBe(PNG_BYTES.byteLength);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.model).toBe(env.IMAGE_MODEL);
+    expect(result.costUsd).toBeCloseTo(0.003, 4);
+
+    const [predUrl, predInit] = fetchImpl.mock.calls[0];
+    expect(predUrl).toBe(
+      `https://api.replicate.com/v1/models/${env.IMAGE_MODEL}/predictions`,
+    );
+    const headers = (predInit as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${env.IMAGE_API_KEY}`);
+    expect(headers.Prefer).toBe("wait");
+    const body = JSON.parse(String((predInit as RequestInit).body));
+    expect(body.input.prompt).toBe("alpine cirque");
+    expect(body.input.aspect_ratio).toBe("16:9");
+
+    const [imageUrl] = fetchImpl.mock.calls[1];
+    expect(imageUrl).toBe("https://replicate.delivery/foo.png");
+  });
+
+  test("output as a single URL string (not an array) is supported", async () => {
+    fetchImpl
+      .mockResolvedValueOnce(
+        predictionResponse({
+          id: "pred-1",
+          status: "succeeded",
+          output: "https://replicate.delivery/single.webp",
+        }),
+      )
+      .mockResolvedValueOnce(imageResponse(PNG_BYTES, "image/webp"));
+
+    const result = await generateImage({ prompt: "x", env, fetchImpl });
+    expect(result.mimeType).toBe("image/webp");
+  });
+
+  test("aspectRatio is omitted from input when not provided", async () => {
+    fetchImpl
+      .mockResolvedValueOnce(
+        predictionResponse({
+          id: "pred-1",
+          status: "succeeded",
+          output: ["https://replicate.delivery/x.png"],
+        }),
+      )
+      .mockResolvedValueOnce(imageResponse(PNG_BYTES));
+
+    await generateImage({ prompt: "x", env, fetchImpl });
+    const body = JSON.parse(String((fetchImpl.mock.calls[0][1] as RequestInit).body));
+    expect(body.input.aspect_ratio).toBeUndefined();
+  });
+});
+
+describe("generateImage — failure paths", () => {
+  test("Replicate 4xx surfaces as ImageGenError with provider response", async () => {
+    fetchImpl.mockResolvedValueOnce(
+      new Response("invalid model version", { status: 422 }),
+    );
+    await expect(generateImage({ prompt: "x", env, fetchImpl })).rejects.toMatchObject({
+      name: "ImageGenError",
+      status: 422,
+    });
+  });
+
+  test("prediction returns status=failed → ImageGenError", async () => {
+    fetchImpl.mockResolvedValueOnce(
+      predictionResponse({
+        id: "pred-1",
+        status: "failed",
+        error: "model crashed",
+      }),
+    );
+    await expect(generateImage({ prompt: "x", env, fetchImpl })).rejects.toThrow(
+      /did not succeed/,
+    );
+  });
+
+  test("prediction succeeded but empty output → ImageGenError", async () => {
+    fetchImpl.mockResolvedValueOnce(
+      predictionResponse({
+        id: "pred-1",
+        status: "succeeded",
+        output: [],
+      }),
+    );
+    await expect(generateImage({ prompt: "x", env, fetchImpl })).rejects.toThrow(
+      /empty or not a URL/,
+    );
+  });
+
+  test("image fetch failure (HTTP error) → ImageGenError", async () => {
+    fetchImpl
+      .mockResolvedValueOnce(
+        predictionResponse({
+          id: "pred-1",
+          status: "succeeded",
+          output: ["https://replicate.delivery/foo.png"],
+        }),
+      )
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }));
+    await expect(generateImage({ prompt: "x", env, fetchImpl })).rejects.toMatchObject({
+      name: "ImageGenError",
+      status: 404,
+    });
+  });
+
+  test("network error contacting Replicate → ImageGenError(status=0)", async () => {
+    fetchImpl.mockRejectedValueOnce(new TypeError("connection refused"));
+    await expect(generateImage({ prompt: "x", env, fetchImpl })).rejects.toMatchObject({
+      name: "ImageGenError",
+      status: 0,
+    });
+  });
+
+  test("rejects non-replicate IMAGE_PROVIDER", async () => {
+    const badEnv = makeTestEnv({ IMAGE_PROVIDER: "openai" });
+    await expect(generateImage({ prompt: "x", env: badEnv, fetchImpl })).rejects.toThrow(
+      /unsupported IMAGE_PROVIDER/,
+    );
+  });
+});
+
+describe("ImageGenError — shape", () => {
+  test("name, status, and providerResponse are exposed", () => {
+    const err = new ImageGenError({ status: 503, message: "x", providerResponse: "service down" });
+    expect(err.name).toBe("ImageGenError");
+    expect(err.status).toBe(503);
+    expect(err.providerResponse).toBe("service down");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,6 +30,10 @@ RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
 JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html"
+# Image-gen (P2-17) — Replicate Flux schnell for the first cut.
+IMAGE_PROVIDER = "replicate"
+IMAGE_MODEL = "black-forest-labs/flux-schnell"
+IMAGE_COST_PER_CALL_USD = "0.003"
 
 # KV namespaces — provisioned per env (dev main + dev preview + staging + production).
 # To recreate from scratch: `wrangler kv namespace create <BINDING> [--preview | --env <env>]`.
@@ -65,6 +69,7 @@ preview_id = "dd4bbcafe4974a65b3f554566c1e2a59"
 #   GITHUB_JOURNAL_TOKEN          — fine-grained PAT (contents:write on journal repo)
 #   GITHUB_JOURNAL_REPO           — e.g. brockamer/trailscribe-journal
 #   GITHUB_JOURNAL_BRANCH         — e.g. main
+#   IMAGE_API_KEY                 — image-gen provider key (Replicate token in α; P2-17 / !postimg)
 
 # -----------------------------------------------------------------------------
 # Staging environment (auto-deployed by .github/workflows/deploy-cloudflare.yml
@@ -96,6 +101,9 @@ RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe (staging)"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
 JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html"
+IMAGE_PROVIDER = "replicate"
+IMAGE_MODEL = "black-forest-labs/flux-schnell"
+IMAGE_COST_PER_CALL_USD = "0.003"
 
 [[env.staging.kv_namespaces]]
 binding = "TS_IDEMPOTENCY"
@@ -140,6 +148,9 @@ RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
 JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{mm}/{dd}/{slug}.html"
+IMAGE_PROVIDER = "replicate"
+IMAGE_MODEL = "black-forest-labs/flux-schnell"
+IMAGE_COST_PER_CALL_USD = "0.003"
 
 [[env.production.kv_namespaces]]
 binding = "TS_IDEMPOTENCY"


### PR DESCRIPTION
## Summary

The image-gen half of the `!postimg` pipeline. P2-18 ships the pipeline itself; this PR delivers the three foundation pieces it consumes.

- **`src/adapters/ai/replicate.ts`** — `generateImage({ prompt, aspectRatio, env })` using Replicate's `Prefer: wait` for synchronous calls. Two HTTP hops (predict, fetch output URL) wrapped in a typed `ImageGenError` so P2-18's handler can fall back to text-only `!post` on any failure.
- **`src/core/imageprompt.ts`** — `buildImagePrompt` grounds the image in device telemetry (place, coords, altitude, local time, weather) + operator caption. Always-on realism guards (no text overlays, no fake landmarks, lighting matches local time) encode #125's constraints. Deterministic for snapshot-test parity.
- **`src/core/ledger.ts`** — new `recordImageTransaction` with parallel `image_requests` / `image_usd_cost` aggregates on `LedgerSnapshot`. **Backwards-compat critical:** the existing `recordTransaction` signature is unchanged; the new fields are optional with `?? 0` read-time coalescing, so pre-P2-17 production snapshots remain readable. `mergeEntry` preserves image fields across text writes.

Locked to **Replicate Flux schnell** for the first cut to keep `!postimg` under PRD §7's $0.05 ceiling without a premium-class exception. Provider upgrade is filed as P2-18b, gated on real field-quality data — not eligible for promotion until operator has on-phone image samples to assess.

## Wrangler / env wiring

| Var / Secret | Type | Default | Notes |
|---|---|---|---|
| `IMAGE_PROVIDER` | var | `"replicate"` | zod enum — only `replicate` accepted |
| `IMAGE_MODEL` | var | `"black-forest-labs/flux-schnell"` | model slug for predictions-by-model endpoint |
| `IMAGE_COST_PER_CALL_USD` | var | `"0.003"` | ledger seed cost (Flux schnell ≈ $0.003) |
| `IMAGE_API_KEY` | secret | — | Replicate API token |

All three vars added to `[vars]`, `[env.staging.vars]`, and `[env.production.vars]` in wrangler.toml. Secret is Wrangler-side; `.dev.vars.example` updated.

## Phase 2 foundation sweep — final PR

1. ✅ P2-02 grammar — #132
2. ✅ P2-01 FieldLog — #133
3. ✅ P2-09 address book — #134
4. **P2-17 image-gen + prompt builder + ledger axis (this PR)**

Plan reference: `plans/phase-2-extended-commands.md` §P2-17.
Refs: #98 #125.

## Acceptance criteria coverage

- [x] `generateImage` happy path returns binary bytes + cost; failure paths throw typed `ImageGenError` with provider response.
- [x] `buildImagePrompt` deterministic for same inputs (snapshot tests); includes every grounding axis when present, omits gracefully when absent.
- [x] Ledger `image_requests` / `image_usd_cost` accumulate; existing text-spend ledger entries unchanged; backwards-compat with pre-P2-17 snapshots verified.
- [x] Wrangler `.dev.vars.example` updated; CLAUDE.md secrets list already mentions `IMAGE_API_KEY` + `IMAGE_*` vars (added when the plan was filed).
- [x] Vitest: `generateImage` happy + 6 failure paths with mocked HTTP; `buildImagePrompt` snapshots for 3 telemetry profiles (alpine, coastal bluff, desert flank) + graceful-omission cases; ledger image-axis behavior + legacy-snapshot upgrade.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm test` — 216/216 green; 25 new tests; no regressions.
- [ ] After merge: provision `IMAGE_API_KEY` on staging — `echo -n "<replicate-token>" | wrangler secret put IMAGE_API_KEY --env staging` (per `feedback_secret_pasting.md`, use `echo -n`).
- [ ] After merge: smoke-test the adapter end-to-end before P2-18 starts — `curl` the worker with a hand-crafted `!postimg` event in dry-run mode and verify Replicate logs an actual prediction.

## Branch overlap with #134

Both PRs touch `src/env.ts`, `tests/helpers/env.ts`, `.dev.vars.example`. Trivial 3-way merge — whichever lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)