### PR TITLE
feat(commands): !where reverse-geocode + map links (P2-03)

### DIFF
--- a/src/core/commands/where.ts
+++ b/src/core/commands/where.ts
@@ -1,0 +1,64 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { reverseGeocode } from "../../adapters/location/geocode.js";
+import { recordTransaction } from "../ledger.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type WhereCommand = Extract<ParsedCommand, { type: "where" }>;
+
+const NO_FIX_REPLY = "Need GPS fix — try again outdoors.";
+const REPLY_MAX = 320;
+
+/**
+ * `!where` pipeline (plan P2-03). Reverse-geocode the device's current GPS
+ * fix and reply with `<place>. <Maps link> <MapShare link>` capped at the
+ * 320-char two-SMS budget. No LLM call, no idempotency-checkpointed step:
+ * `reverseGeocode` is a pure read with KV caching, so a Garmin retry is
+ * naturally a cache hit.
+ *
+ * No-fix path (`lat`/`lon` undefined) replies with a fixed prompt so the
+ * operator knows to step out from under canopy. Geocode failures already
+ * collapse inside `reverseGeocode` (returns `"unknown location"`), so the
+ * handler never sees a thrown error from that call.
+ */
+export async function handleWhere(
+  _cmd: WhereCommand,
+  ctx: OrchestratorContext,
+): Promise<CommandResult> {
+  const { env, lat, lon } = ctx;
+
+  if (lat === undefined || lon === undefined) {
+    await recordWhereLedger(ctx);
+    return { body: NO_FIX_REPLY };
+  }
+
+  const placeName = await reverseGeocode(lat, lon, env);
+  const mapsUrl = `${env.GOOGLE_MAPS_BASE}${lat},${lon}`;
+  const mapShareUrl = env.MAPSHARE_BASE;
+  const links = mapShareUrl ? `${mapsUrl} ${mapShareUrl}` : mapsUrl;
+  const body = capReply(`${placeName}. ${links}`);
+
+  await recordWhereLedger(ctx);
+  return { body };
+}
+
+function capReply(s: string): string {
+  return s.length > REPLY_MAX ? s.slice(0, REPLY_MAX) : s;
+}
+
+async function recordWhereLedger(ctx: OrchestratorContext): Promise<void> {
+  try {
+    await recordTransaction({
+      command: "where",
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+      env: ctx.env,
+    });
+  } catch (err) {
+    log({
+      event: "where_ledger_write_failed",
+      level: "warn",
+      imei: ctx.imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -4,6 +4,7 @@ import { monthlyTotals, recordTransaction, type LedgerSnapshot } from "./ledger.
 import { handlePost } from "./commands/post.js";
 import { handleMail } from "./commands/mail.js";
 import { handleTodo } from "./commands/todo.js";
+import { handleWhere } from "./commands/where.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -51,6 +52,7 @@ export async function orchestrate(
     case "todo":
       return handleTodo(command, ctx);
     case "where":
+      return handleWhere(command, ctx);
     case "weather":
     case "drop":
     case "brief":

--- a/tests/p2-03-where.test.ts
+++ b/tests/p2-03-where.test.ts
@@ -1,0 +1,227 @@
+/**
+ * P2-03 — End-to-end integration tests for !where pipeline.
+ *
+ * Drives the Worker via app.request(...) with a real orchestrator and a
+ * mocked sendReply + mocked Nominatim. Asserts:
+ *   - Happy path: place name + Maps link + MapShare link in the device reply.
+ *   - No-GPS-fix path: returns the canonical "Need GPS fix" prompt; Nominatim
+ *     is never hit.
+ *   - Geocode failure path: place collapses to "unknown location" via the
+ *     reverseGeocode FALLBACK; raw coords still surface via the Maps URL.
+ *   - Ledger always records `cmd: 'where'` with usd_cost: 0 (telemetry parity
+ *     with !ping; no-fix invocations count too).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+const LAT = 37.1682;
+const LON = -118.5891;
+const MAPSHARE = "https://share.garmin.com/MyMap";
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function envelope(
+  freeText: string,
+  opts: { ts?: number; gps?: { lat: number; lon: number } } = {},
+) {
+  const point = opts.gps
+    ? { latitude: opts.gps.lat, longitude: opts.gps.lon, altitude: 1000, gpsFix: 2 }
+    : { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 };
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point,
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+function makeFetchRouter(
+  routes: Array<{
+    match: (url: string) => boolean;
+    respond: () => Response | Promise<Response>;
+  }>,
+) {
+  return vi.fn(async (url: URL | RequestInfo) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const r of routes) {
+      if (r.match(u)) return await r.respond();
+    }
+    throw new Error(`unmatched fetch: ${u}`);
+  });
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({ MAPSHARE_BASE: MAPSHARE });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P2-03 !where — happy path with GPS", () => {
+  test("calls geocode; reply contains place name + Maps link + MapShare link", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () =>
+          jsonResponse({
+            display_name: "Lake Sabrina, Inyo County, California",
+            address: { locality: "Lake Sabrina", state: "California" },
+          }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!where", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("Lake Sabrina, California");
+    expect(joined).toContain(`https://www.google.com/maps/search/?api=1&query=${LAT},${LON}`);
+    expect(joined).toContain(MAPSHARE);
+    expect(joined.length).toBeLessThanOrEqual(320);
+
+    // Hit Nominatim once, no other outbound calls.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("nominatim.openstreetmap.org");
+  });
+
+  test("records a 0-cost ledger transaction tagged cmd=where", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () =>
+          jsonResponse({
+            address: { locality: "Onion Valley", state: "California" },
+          }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!where", { gps: { lat: LAT, lon: LON } }));
+
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(1);
+    expect(snap.usd_cost).toBe(0);
+    expect(snap.by_command["where"]).toEqual({ requests: 1, usd_cost: 0 });
+  });
+
+  test("MAPSHARE_BASE empty → reply omits the MapShare link, Maps link still present", async () => {
+    env = makeTestEnv({ MAPSHARE_BASE: "" });
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () => jsonResponse({ address: { locality: "Lake Sabrina", state: "California" } }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!where", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("Lake Sabrina, California");
+    expect(joined).toContain("google.com/maps");
+    expect(joined).not.toContain("share.garmin.com");
+  });
+});
+
+describe("P2-03 !where — no GPS fix", () => {
+  test("returns the canonical 'Need GPS fix' prompt; never calls Nominatim", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!where")); // gpsFix=0, lat=0, lon=0
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Need GPS fix — try again outdoors."]);
+  });
+
+  test("still records a 0-cost ledger transaction (telemetry parity)", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    }) as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!where"));
+
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(1);
+    expect(snap.by_command["where"]).toEqual({ requests: 1, usd_cost: 0 });
+  });
+});
+
+describe("P2-03 !where — geocode failure", () => {
+  test("Nominatim 500 → reply uses 'unknown location' fallback + raw coords via Maps URL", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () => new Response("server error", { status: 500 }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!where", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("unknown location");
+    // Raw coords still reach the user via the Maps URL — that's the "+ raw coords"
+    // half of the acceptance criterion.
+    expect(joined).toContain(`${LAT},${LON}`);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #112 (P2-03). Replaces the orchestrator's stub-throw `case 'where':`
arm with a real handler that:

- Reverse-geocodes the device's current GPS fix (reuses the Phase 1
  `reverseGeocode` adapter — no new deps, no new secrets).
- Replies with `<place>. <Maps link> <MapShare link>` capped at the
  320-char two-SMS budget.
- Falls back to `Need GPS fix — try again outdoors.` when the Mini
  hasn't locked yet.
- Records a 0-cost ledger entry tagged `cmd: 'where'` (telemetry parity
  with `!ping`; no-fix invocations count too so `!cost` shows the full
  picture).

The on-device URLs aren't tappable in the field, but they sit in the
operator's Messages app and become useful once back in cell coverage —
same pattern as the journal URL in `!post`'s reply.

## Engineering shape

- New file `src/core/commands/where.ts`.
- Two-line edit to `src/core/orchestrator.ts` carving `case 'where':`
  out of the Phase 2 stub fall-through. The other 8 stubs stay in the
  fall-through `throw`, so each subsequent Phase 2 PR can pluck its
  case out the same way without colliding.
- New test file `tests/p2-03-where.test.ts` (6 cases: happy path with
  both links, ledger accounting, MAPSHARE_BASE empty path, no-GPS-fix
  reply, no-GPS-fix ledger, geocode-failure fallback).

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — 271/271 (was 265 + 6 new)
- [ ] Staging deploy + 3-fixture manual verification (per acceptance bullet 6)
- [ ] Real-device verification on the Mini (rolls into P2-16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)