### PR TITLE
feat(commands): !ai LLM Q&A with email overflow (P2-07)

### DIFF
--- a/src/core/commands/ai.ts
+++ b/src/core/commands/ai.ts
@@ -1,0 +1,137 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { chatCompletion, LLMError } from "../../adapters/ai/openrouter.js";
+import { sendEmail, ResendError } from "../../adapters/mail/resend.js";
+import { recordTransaction } from "../ledger.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { BUDGET_REJECTION_MESSAGE, checkBudget } from "../budget.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type AiCommand = Extract<ParsedCommand, { type: "ai" }>;
+
+const REPLY_MAX = 320;
+const ESTIMATED_AI_TOKENS = 600;
+const SUBJECT_PREVIEW_MAX = 40;
+const OVERFLOW_REPLY = "Long answer sent by email.";
+
+const SYSTEM_PROMPT =
+  "You are TrailScribe's field research assistant. Answer the user's " +
+  "question concisely. Aim for 280 characters or fewer; if more is needed, " +
+  "write the full answer and we will route it to email.";
+
+/**
+ * `!ai <question>` pipeline (plan P2-07). Open-ended LLM Q&A via OpenRouter.
+ *
+ * Reply path:
+ *   - LLM output ≤ 320 chars: reply directly on device.
+ *   - LLM output > 320 chars: reply `Long answer sent by email.` and Resend
+ *     the full answer to the operator email.
+ *
+ * The LLM call is checkpointed so a Garmin retry storm does not double-bill
+ * OpenRouter. The Resend send is also checkpointed under a separate op so a
+ * mid-retry can short-circuit the email send too.
+ *
+ * Empty question is rejected upstream by the grammar.
+ */
+export async function handleAi(cmd: AiCommand, ctx: OrchestratorContext): Promise<CommandResult> {
+  const { env, imei, idemKey } = ctx;
+
+  const budget = await checkBudget(env, ESTIMATED_AI_TOKENS);
+  if (!budget.allowed) {
+    log({ event: "ai_budget_rejected", level: "warn", imei, remaining: budget.remaining });
+    return { body: BUDGET_REJECTION_MESSAGE };
+  }
+
+  let result: { content: string; usage: { prompt_tokens: number; completion_tokens: number } };
+  try {
+    result = await withCheckpoint(env, idemKey, "ai", async () => {
+      const completion = await chatCompletion({
+        req: {
+          model: env.LLM_MODEL,
+          messages: [
+            { role: "system", content: SYSTEM_PROMPT },
+            { role: "user", content: cmd.question },
+          ],
+        },
+        env,
+      });
+      const content = completion.choices[0]?.message.content ?? "";
+      return {
+        content,
+        usage: {
+          prompt_tokens: completion.usage.prompt_tokens,
+          completion_tokens: completion.usage.completion_tokens,
+        },
+      };
+    });
+  } catch (err) {
+    return failPipeline(env, idemKey, "ai", err, imei);
+  }
+
+  // Ledger always records — even if email overflow path runs we want the LLM
+  // cost captured.
+  try {
+    await recordTransaction({
+      command: "ai",
+      usage: result.usage,
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "ai_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const content = result.content.trim();
+  if (content.length === 0) {
+    return { body: "AI returned empty reply. Try rephrasing." };
+  }
+  if (content.length <= REPLY_MAX) {
+    return { body: content };
+  }
+
+  // Overflow: route the full answer via email; device gets the short pointer.
+  try {
+    await withCheckpoint(env, idemKey, "ai_overflow_email", async () => {
+      const subjectPreview =
+        cmd.question.length > SUBJECT_PREVIEW_MAX
+          ? cmd.question.slice(0, SUBJECT_PREVIEW_MAX)
+          : cmd.question;
+      const sendResult = await sendEmail({
+        to: env.RESEND_FROM_EMAIL,
+        subject: `TrailScribe !ai: ${subjectPreview}`,
+        body: `Question:\n${cmd.question}\n\n---\n\n${content}`,
+        env,
+      });
+      return { id: sendResult.id };
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "ai_overflow_email_failed", level: "error", imei, error: msg });
+    if (err instanceof ResendError) {
+      return { body: `AI overflow email failed: ${msg.slice(0, 80)}` };
+    }
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  return { body: OVERFLOW_REPLY };
+}
+
+async function failPipeline(
+  env: OrchestratorContext["env"],
+  idemKey: string,
+  step: string,
+  err: unknown,
+  imei: string,
+): Promise<CommandResult> {
+  const msg = err instanceof Error ? err.message : String(err);
+  log({ event: `ai_${step}_failed`, level: "error", imei, error: msg });
+  await markFailed(env, idemKey, `${step}: ${msg}`);
+  if (err instanceof LLMError) {
+    return { body: `AI failed: ${msg.slice(0, 80)}` };
+  }
+  return { body: `Error: ${msg.slice(0, 80)}` };
+}

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -45,7 +45,9 @@ export type OpName =
   | "todo"
   | "reply"
   | "brief"
-  | "brief_overflow_email";
+  | "brief_overflow_email"
+  | "ai"
+  | "ai_overflow_email";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -8,6 +8,7 @@ import { handleWhere } from "./commands/where.js";
 import { handleWeather } from "./commands/weather.js";
 import { handleDrop } from "./commands/drop.js";
 import { handleBrief } from "./commands/brief.js";
+import { handleAi } from "./commands/ai.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -56,13 +57,14 @@ export async function orchestrate(
       return handleTodo(command, ctx);
     case "where":
       return handleWhere(command, ctx);
-    case "brief":
-      return handleBrief(command, ctx);
     case "weather":
       return handleWeather(command, ctx);
     case "drop":
       return handleDrop(command, ctx);
+    case "brief":
+      return handleBrief(command, ctx);
     case "ai":
+      return handleAi(command, ctx);
     case "camp":
     case "share":
     case "blast":

--- a/tests/p2-07-ai.test.ts
+++ b/tests/p2-07-ai.test.ts
@@ -1,0 +1,231 @@
+/**
+ * P2-07 — End-to-end integration tests for !ai pipeline.
+ *
+ * Asserts:
+ *   - Short reply happy path: device reply is the LLM content; ledger captures
+ *     real OpenRouter usage; no email send.
+ *   - Long reply email path: device reply is the canned overflow pointer;
+ *     full LLM output goes to the operator email via Resend.
+ *   - Budget gate: short-circuits before any LLM call.
+ *   - Idempotency: replay does not double-bill the LLM or double-send email.
+ *   - Empty question: rejected upstream by the grammar; handler not invoked.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals, recordTransaction } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function chatCompletionResponse(content: string, prompt = 50, completion = 100) {
+  return {
+    id: "chatcmpl-test",
+    choices: [{ message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion },
+  };
+}
+
+function envelope(freeText: string, opts: { ts?: number } = {}) {
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point: { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 },
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+function makeFetchRouter(
+  routes: Array<{ match: (url: string) => boolean; respond: () => Response | Promise<Response> }>,
+) {
+  return vi.fn(async (url: URL | RequestInfo) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const r of routes) {
+      if (r.match(u)) return await r.respond();
+    }
+    throw new Error(`unmatched fetch: ${u}`);
+  });
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({
+    LLM_INPUT_COST_PER_1K: "0.003",
+    LLM_OUTPUT_COST_PER_1K: "0.015",
+  });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P2-07 !ai — short reply happy path", () => {
+  test("LLM content ≤ 320 chars goes straight to the device; no email send", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse("Granite is an igneous rock formed from cooled magma.")),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!ai what is granite"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Granite is an igneous rock formed from cooled magma."]);
+
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes("api.resend.com"))).toBe(false);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(1);
+    expect(snap.by_command["ai"].requests).toBe(1);
+    expect(snap.prompt_tokens).toBe(50);
+    expect(snap.completion_tokens).toBe(100);
+  });
+});
+
+describe("P2-07 !ai — long reply email path", () => {
+  test("LLM content > 320 chars: device gets pointer; Resend gets full answer", async () => {
+    const longAnswer = "x".repeat(500);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse(longAnswer)),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_long" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!ai explain mineralogy in great detail"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Long answer sent by email."]);
+
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCall).toBeDefined();
+    const sentBody = JSON.parse((resendCall![1] as RequestInit).body as string) as {
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(sentBody.to).toBe(env.RESEND_FROM_EMAIL);
+    expect(sentBody.subject).toContain("TrailScribe !ai");
+    expect(sentBody.subject).toContain("explain mineralogy");
+    expect(sentBody.text).toContain(longAnswer);
+    expect(sentBody.text).toContain("Question:");
+  });
+});
+
+describe("P2-07 !ai — budget gate", () => {
+  test("daily budget exhausted: short-circuits before any LLM call", async () => {
+    // Seed today's daily ledger past the 50,000-token budget.
+    const overBudgetUsage = { prompt_tokens: 40000, completion_tokens: 12000 };
+    await recordTransaction({ command: "post", usage: overBudgetUsage, env });
+
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!ai test budget"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toContain("Daily AI budget reached");
+  });
+});
+
+describe("P2-07 !ai — idempotency", () => {
+  test("replay of the same event hits LLM once and emails once", async () => {
+    const longAnswer = "y".repeat(500);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse(longAnswer)),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_replay" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const ev = envelope("!ai replay test", { ts: 9876 });
+    await postIpc(ev);
+    await postIpc(ev);
+
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    const llmCalls = calls.filter((u) => u.includes("openrouter") || u.includes("/chat/completions"));
+    const emailCalls = calls.filter((u) => u.includes("api.resend.com"));
+    expect(llmCalls).toHaveLength(1);
+    expect(emailCalls).toHaveLength(1);
+  });
+});
+
+describe("P2-07 !ai — empty question", () => {
+  test("rejected at parse time; LLM never called", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!ai"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Unknown command. Try !help"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #116 (P2-07). Open-ended LLM Q&A via OpenRouter. Replies ≤320 chars go to the device; longer answers route to operator email via Resend (mirrors !post's overflow pattern).

## Pipeline

\`\`\`
budget gate → LLM (checkpointed) → ledger → reply OR email overflow (checkpointed)
\`\`\`

Both side-effecting ops are wrapped in \`withCheckpoint\` so a Garmin retry storm bills OpenRouter exactly once and sends the overflow email exactly once. The \`OpName\` union in \`idempotency.ts\` gains \`ai\` + \`ai_overflow_email\` arms.

## Behavior

- **Short reply:** LLM content goes straight to device.
- **Long reply (>320 chars):** device receives \`Long answer sent by email.\`; full answer + original question lands in the operator inbox at \`RESEND_FROM_EMAIL\` with subject \`TrailScribe !ai: <question preview>\`.
- **Daily token budget:** short-circuits before any LLM call when exhausted; reply is the canned \`BUDGET_REJECTION_MESSAGE\`.
- **Empty question:** rejected upstream by the grammar; handler not invoked.
- **Replay:** LLM call hits exactly once across retries; email send hits exactly once.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 276/276 (was 271 + 5 new, against current main; will increase further once #137/#138 merge)
- [ ] Real-device verification (rolls into P2-16)

> Branch is based on \`main\` before #137/#138/#139/#140 merge. Will rebase cleanly; orchestrator overlap is a single case-block addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)