### PR TITLE
feat(commands): !camp LLM-only outdoors lookup (P2-08)

### DIFF
--- a/src/core/commands/camp.ts
+++ b/src/core/commands/camp.ts
@@ -1,0 +1,139 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { chatCompletion, LLMError } from "../../adapters/ai/openrouter.js";
+import { sendEmail, ResendError } from "../../adapters/mail/resend.js";
+import { recordTransaction } from "../ledger.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { BUDGET_REJECTION_MESSAGE, checkBudget } from "../budget.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type CampCommand = Extract<ParsedCommand, { type: "camp" }>;
+
+const REPLY_MAX = 320;
+const ESTIMATED_CAMP_TOKENS = 600;
+const SUBJECT_PREVIEW_MAX = 40;
+const STALENESS_PREFIX = "(may be outdated) ";
+const OVERFLOW_REPLY = "Long answer sent by email.";
+
+const SYSTEM_PROMPT =
+  "You are TrailScribe's outdoors-knowledge assistant. The user is in the " +
+  "field with no internet. Answer their question about camping, water " +
+  "sources, or outdoor features concisely. Be conservative — say " +
+  '"uncertain" rather than guess. Aim for 280 characters.';
+
+/**
+ * `!camp <query>` pipeline (plan P2-08). LLM-only first cut: the model
+ * answers from general knowledge and the reply is prefixed with
+ * "(may be outdated)" so the operator never confuses field guidance with
+ * real-time data. Real web-search integration is filed as P2-08b — not
+ * blocking Phase 2 close.
+ *
+ * Mirrors `!ai`: budget gate → LLM (checkpointed) → ledger → reply or
+ * overflow-to-email. Same idempotency posture.
+ */
+export async function handleCamp(
+  cmd: CampCommand,
+  ctx: OrchestratorContext,
+): Promise<CommandResult> {
+  const { env, imei, idemKey } = ctx;
+
+  const budget = await checkBudget(env, ESTIMATED_CAMP_TOKENS);
+  if (!budget.allowed) {
+    log({ event: "camp_budget_rejected", level: "warn", imei, remaining: budget.remaining });
+    return { body: BUDGET_REJECTION_MESSAGE };
+  }
+
+  let result: { content: string; usage: { prompt_tokens: number; completion_tokens: number } };
+  try {
+    result = await withCheckpoint(env, idemKey, "camp", async () => {
+      const completion = await chatCompletion({
+        req: {
+          model: env.LLM_MODEL,
+          messages: [
+            { role: "system", content: SYSTEM_PROMPT },
+            { role: "user", content: cmd.query },
+          ],
+        },
+        env,
+      });
+      const content = completion.choices[0]?.message.content ?? "";
+      return {
+        content,
+        usage: {
+          prompt_tokens: completion.usage.prompt_tokens,
+          completion_tokens: completion.usage.completion_tokens,
+        },
+      };
+    });
+  } catch (err) {
+    return failPipeline(env, idemKey, "camp", err, imei);
+  }
+
+  try {
+    await recordTransaction({
+      command: "camp",
+      usage: result.usage,
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "camp_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const content = result.content.trim();
+  if (content.length === 0) {
+    return { body: "Camp lookup returned empty. Try rephrasing." };
+  }
+
+  const prefixed = STALENESS_PREFIX + content;
+  if (prefixed.length <= REPLY_MAX) {
+    return { body: prefixed };
+  }
+
+  // Overflow → email full answer (with the staleness prefix preserved on the
+  // device pointer reply via OVERFLOW_REPLY's wording).
+  try {
+    await withCheckpoint(env, idemKey, "camp_overflow_email", async () => {
+      const subjectPreview =
+        cmd.query.length > SUBJECT_PREVIEW_MAX
+          ? cmd.query.slice(0, SUBJECT_PREVIEW_MAX)
+          : cmd.query;
+      const sendResult = await sendEmail({
+        to: env.RESEND_FROM_EMAIL,
+        subject: `TrailScribe !camp: ${subjectPreview}`,
+        body: `Query:\n${cmd.query}\n\n---\n\n${prefixed}`,
+        env,
+      });
+      return { id: sendResult.id };
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "camp_overflow_email_failed", level: "error", imei, error: msg });
+    if (err instanceof ResendError) {
+      return { body: `Camp overflow email failed: ${msg.slice(0, 80)}` };
+    }
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  return { body: OVERFLOW_REPLY };
+}
+
+async function failPipeline(
+  env: OrchestratorContext["env"],
+  idemKey: string,
+  step: string,
+  err: unknown,
+  imei: string,
+): Promise<CommandResult> {
+  const msg = err instanceof Error ? err.message : String(err);
+  log({ event: `camp_${step}_failed`, level: "error", imei, error: msg });
+  await markFailed(env, idemKey, `${step}: ${msg}`);
+  if (err instanceof LLMError) {
+    return { body: `Camp lookup failed: ${msg.slice(0, 80)}` };
+  }
+  return { body: `Error: ${msg.slice(0, 80)}` };
+}

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -47,7 +47,9 @@ export type OpName =
   | "brief"
   | "brief_overflow_email"
   | "ai"
-  | "ai_overflow_email";
+  | "ai_overflow_email"
+  | "camp"
+  | "camp_overflow_email";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -9,6 +9,7 @@ import { handleWeather } from "./commands/weather.js";
 import { handleDrop } from "./commands/drop.js";
 import { handleBrief } from "./commands/brief.js";
 import { handleAi } from "./commands/ai.js";
+import { handleCamp } from "./commands/camp.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -66,6 +67,7 @@ export async function orchestrate(
     case "ai":
       return handleAi(command, ctx);
     case "camp":
+      return handleCamp(command, ctx);
     case "share":
     case "blast":
     case "postimg":

--- a/tests/p2-08-camp.test.ts
+++ b/tests/p2-08-camp.test.ts
@@ -1,0 +1,230 @@
+/**
+ * P2-08 — End-to-end integration tests for !camp pipeline.
+ *
+ * Asserts:
+ *   - Short reply: device gets `(may be outdated) <answer>`.
+ *   - Long reply: device gets the canned overflow pointer; full prefixed
+ *     answer routes to the operator email.
+ *   - Budget gate: short-circuits before any LLM call.
+ *   - Idempotency: replay does not double-bill the LLM or double-send email.
+ *   - Empty query: rejected upstream by the grammar; handler not invoked.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals, recordTransaction } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function chatCompletionResponse(content: string, prompt = 60, completion = 80) {
+  return {
+    id: "chatcmpl-test",
+    choices: [{ message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion },
+  };
+}
+
+function envelope(freeText: string, opts: { ts?: number } = {}) {
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point: { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 },
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+function makeFetchRouter(
+  routes: Array<{ match: (url: string) => boolean; respond: () => Response | Promise<Response> }>,
+) {
+  return vi.fn(async (url: URL | RequestInfo) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const r of routes) {
+      if (r.match(u)) return await r.respond();
+    }
+    throw new Error(`unmatched fetch: ${u}`);
+  });
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({
+    LLM_INPUT_COST_PER_1K: "0.003",
+    LLM_OUTPUT_COST_PER_1K: "0.015",
+  });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P2-08 !camp — short reply happy path", () => {
+  test("device gets `(may be outdated) <answer>`; ledger captures usage", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse("Onion Valley has dispersed sites along the creek.")),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!camp water Onion Valley"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual([
+      "(may be outdated) Onion Valley has dispersed sites along the creek.",
+    ]);
+
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes("api.resend.com"))).toBe(false);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.by_command["camp"].requests).toBe(1);
+    expect(snap.prompt_tokens).toBe(60);
+    expect(snap.completion_tokens).toBe(80);
+  });
+});
+
+describe("P2-08 !camp — long reply email path", () => {
+  test("> 320 chars: device gets pointer; Resend gets prefixed full answer", async () => {
+    const longAnswer = "z".repeat(500);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse(longAnswer)),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_camp_long" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!camp deep camping research"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Long answer sent by email."]);
+
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCall).toBeDefined();
+    const sentBody = JSON.parse((resendCall![1] as RequestInit).body as string) as {
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(sentBody.to).toBe(env.RESEND_FROM_EMAIL);
+    expect(sentBody.subject).toContain("TrailScribe !camp");
+    expect(sentBody.text).toContain("(may be outdated) " + longAnswer);
+  });
+});
+
+describe("P2-08 !camp — budget gate", () => {
+  test("daily budget exhausted: short-circuits before any LLM call", async () => {
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 40000, completion_tokens: 12000 },
+      env,
+    });
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!camp test budget"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toContain("Daily AI budget reached");
+  });
+});
+
+describe("P2-08 !camp — idempotency", () => {
+  test("replay hits LLM once and emails once", async () => {
+    const longAnswer = "w".repeat(500);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse(longAnswer)),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_camp_replay" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const ev = envelope("!camp replay test", { ts: 5555 });
+    await postIpc(ev);
+    await postIpc(ev);
+
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    const llmCalls = calls.filter((u) => u.includes("openrouter") || u.includes("/chat/completions"));
+    const emailCalls = calls.filter((u) => u.includes("api.resend.com"));
+    expect(llmCalls).toHaveLength(1);
+    expect(emailCalls).toHaveLength(1);
+  });
+});
+
+describe("P2-08 !camp — empty query", () => {
+  test("rejected at parse time; LLM never called", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!camp"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Unknown command. Try !help"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #117 (P2-08). LLM-only first cut per the Phase 2 plan's resolved question §1: replies are prefixed with \`(may be outdated)\` so the operator never confuses field guidance with real-time data. Real web-search integration is filed as P2-08b — not blocking Phase 2 close.

## Pipeline

\`\`\`
budget gate → LLM (checkpointed as \`camp\`) → ledger → reply OR
                                              email overflow (checkpointed as \`camp_overflow_email\`)
\`\`\`

Mirrors !ai (#141). Same idempotency posture. Different system prompt: assistant is told the user is offline and to say "uncertain" rather than guess.

## Behavior

- **Short reply:** \`(may be outdated) <answer>\` to device.
- **Long reply (>320 chars):** device receives \`Long answer sent by email.\`; full prefixed answer + original query lands at \`RESEND_FROM_EMAIL\` with subject \`TrailScribe !camp: <query preview>\`.
- **Daily token budget:** short-circuits before any LLM call when exhausted.
- **Empty query:** rejected upstream by the grammar.
- **Replay:** LLM call once; email send once.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 276/276 (5 new, against current main)
- [ ] Real-device verification (rolls into P2-16)

> Branch is based on \`main\` before #137/#138/#139/#140/#141 merge. Will need a rebase to interleave \`OpName\` union extensions with #141's; conflict resolution is mechanical (both PRs add new arms to the same union).

🤖 Generated with [Claude Code](https://claude.com/claude-code)