### PR TITLE
feat(commands): !brief LLM FieldLog summary (P2-06)

### DIFF
--- a/src/core/commands/brief.ts
+++ b/src/core/commands/brief.ts
@@ -1,0 +1,161 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { chatCompletion, LLMError } from "../../adapters/ai/openrouter.js";
+import { sendEmail, ResendError } from "../../adapters/mail/resend.js";
+import { recordTransaction, monthlyTotals } from "../ledger.js";
+import { getEntries, type FieldLogEntry } from "../fieldlog.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { BUDGET_REJECTION_MESSAGE, checkBudget } from "../budget.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type BriefCommand = Extract<ParsedCommand, { type: "brief" }>;
+
+const REPLY_MAX = 320;
+const ESTIMATED_BRIEF_TOKENS = 800;
+const DEFAULT_WINDOW_DAYS = 1;
+const OVERFLOW_REPLY = "Brief sent by email.";
+const NO_ENTRIES_REPLY = "No entries to brief on.";
+
+const SYSTEM_PROMPT =
+  "You are TrailScribe's field briefing writer. Summarize the operator's " +
+  "recent FieldLog entries plus month-to-date activity into a tight 5-line " +
+  "summary. No preamble, no headers — just the lines, separated by " +
+  "newlines. Aim for 280 characters total. Use plain text only.";
+
+/**
+ * `!brief [Nd]` pipeline (plan P2-06). Aggregates FieldLog + ledger and asks
+ * the LLM for a five-line summary. Default window is 24 hours; an optional
+ * `windowDays` argument from the grammar overrides it.
+ *
+ * If the FieldLog is empty for the window, short-circuits with a canned
+ * "no entries" reply (no LLM cost). If the LLM produces a reply that
+ * exceeds 320 chars after page formatting, the device gets a pointer and
+ * the full brief routes to operator email — same overflow pattern as
+ * !ai / !camp / !post.
+ */
+export async function handleBrief(
+  cmd: BriefCommand,
+  ctx: OrchestratorContext,
+): Promise<CommandResult> {
+  const { env, imei, idemKey } = ctx;
+  const windowDays = cmd.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const since = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+
+  const entries = await getEntries(env, imei, { since });
+  if (entries.length === 0) {
+    return { body: NO_ENTRIES_REPLY };
+  }
+
+  const budget = await checkBudget(env, ESTIMATED_BRIEF_TOKENS);
+  if (!budget.allowed) {
+    log({ event: "brief_budget_rejected", level: "warn", imei, remaining: budget.remaining });
+    return { body: BUDGET_REJECTION_MESSAGE };
+  }
+
+  const ledgerSnap = await monthlyTotals(env);
+  const userPrompt = buildUserPrompt(entries, ledgerSnap, windowDays);
+
+  let result: { content: string; usage: { prompt_tokens: number; completion_tokens: number } };
+  try {
+    result = await withCheckpoint(env, idemKey, "brief", async () => {
+      const completion = await chatCompletion({
+        req: {
+          model: env.LLM_MODEL,
+          messages: [
+            { role: "system", content: SYSTEM_PROMPT },
+            { role: "user", content: userPrompt },
+          ],
+        },
+        env,
+      });
+      const content = completion.choices[0]?.message.content ?? "";
+      return {
+        content,
+        usage: {
+          prompt_tokens: completion.usage.prompt_tokens,
+          completion_tokens: completion.usage.completion_tokens,
+        },
+      };
+    });
+  } catch (err) {
+    return failPipeline(env, idemKey, "brief", err, imei);
+  }
+
+  try {
+    await recordTransaction({ command: "brief", usage: result.usage, env });
+  } catch (err) {
+    log({
+      event: "brief_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const content = result.content.trim();
+  if (content.length === 0) {
+    return { body: "Brief returned empty. Try again." };
+  }
+  if (content.length <= REPLY_MAX) {
+    return { body: content };
+  }
+
+  // Overflow → email.
+  try {
+    await withCheckpoint(env, idemKey, "brief_overflow_email", async () => {
+      const sendResult = await sendEmail({
+        to: env.RESEND_FROM_EMAIL,
+        subject: `TrailScribe brief (last ${windowDays}d, ${entries.length} entries)`,
+        body: `Window: last ${windowDays}d\n\n${content}`,
+        env,
+      });
+      return { id: sendResult.id };
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "brief_overflow_email_failed", level: "error", imei, error: msg });
+    if (err instanceof ResendError) {
+      return { body: `Brief overflow email failed: ${msg.slice(0, 80)}` };
+    }
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  return { body: OVERFLOW_REPLY };
+}
+
+function buildUserPrompt(
+  entries: FieldLogEntry[],
+  ledgerSnap: { requests: number; usd_cost: number },
+  windowDays: number,
+): string {
+  const lines = entries
+    .map((e) => {
+      const t = new Date(e.ts).toISOString();
+      const loc = e.lat !== undefined && e.lon !== undefined ? ` @ ${e.lat},${e.lon}` : "";
+      return `- ${t}${loc}: ${e.note}`;
+    })
+    .join("\n");
+  return [
+    `Window: last ${windowDays}d. Entries: ${entries.length}.`,
+    `Month-to-date: ${ledgerSnap.requests} requests, $${ledgerSnap.usd_cost.toFixed(2)}.`,
+    "",
+    "FieldLog entries (chronological):",
+    lines,
+  ].join("\n");
+}
+
+async function failPipeline(
+  env: OrchestratorContext["env"],
+  idemKey: string,
+  step: string,
+  err: unknown,
+  imei: string,
+): Promise<CommandResult> {
+  const msg = err instanceof Error ? err.message : String(err);
+  log({ event: `brief_${step}_failed`, level: "error", imei, error: msg });
+  await markFailed(env, idemKey, `${step}: ${msg}`);
+  if (err instanceof LLMError) {
+    return { body: `Brief failed: ${msg.slice(0, 80)}` };
+  }
+  return { body: `Error: ${msg.slice(0, 80)}` };
+}

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -38,7 +38,14 @@ export async function sha256Hex(input: string): Promise<string> {
  * steps so a typo doesn't silently create a new bucket. Add to this union as
  * new ops appear (e.g. P3 `!camp`).
  */
-export type OpName = "narrative" | "publish" | "mail" | "todo" | "reply";
+export type OpName =
+  | "narrative"
+  | "publish"
+  | "mail"
+  | "todo"
+  | "reply"
+  | "brief"
+  | "brief_overflow_email";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -7,6 +7,7 @@ import { handleTodo } from "./commands/todo.js";
 import { handleWhere } from "./commands/where.js";
 import { handleWeather } from "./commands/weather.js";
 import { handleDrop } from "./commands/drop.js";
+import { handleBrief } from "./commands/brief.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -55,11 +56,12 @@ export async function orchestrate(
       return handleTodo(command, ctx);
     case "where":
       return handleWhere(command, ctx);
+    case "brief":
+      return handleBrief(command, ctx);
     case "weather":
       return handleWeather(command, ctx);
     case "drop":
       return handleDrop(command, ctx);
-    case "brief":
     case "ai":
     case "camp":
     case "share":

--- a/tests/p2-06-brief.test.ts
+++ b/tests/p2-06-brief.test.ts
@@ -1,0 +1,292 @@
+/**
+ * P2-06 — End-to-end integration tests for !brief pipeline.
+ *
+ * Asserts:
+ *   - Empty FieldLog: short-circuits with "No entries to brief on."; LLM
+ *     never called.
+ *   - Happy path with FieldLog entries: LLM call produces a 5-line summary
+ *     ≤320 chars; reply hits the device directly.
+ *   - Long output: device gets `Brief sent by email.`; full content goes
+ *     to operator email.
+ *   - Custom window: `!brief 7d` filters FieldLog to last 7 days.
+ *   - Daily token budget gate: short-circuits LLM call when exhausted.
+ *   - Idempotency: replay does not re-bill the LLM.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { recordTransaction } from "../src/core/ledger.js";
+import { appendEntry } from "../src/core/fieldlog.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+const IMEI = "123456789012345";
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function chatCompletionResponse(content: string, prompt = 100, completion = 150) {
+  return {
+    id: "chatcmpl-test",
+    choices: [{ message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion },
+  };
+}
+
+function envelope(freeText: string, opts: { ts?: number } = {}) {
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: IMEI,
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point: { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 },
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+function makeFetchRouter(
+  routes: Array<{ match: (url: string) => boolean; respond: () => Response | Promise<Response> }>,
+) {
+  return vi.fn(async (url: URL | RequestInfo) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const r of routes) {
+      if (r.match(u)) return await r.respond();
+    }
+    throw new Error(`unmatched fetch: ${u}`);
+  });
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({
+    LLM_INPUT_COST_PER_1K: "0.003",
+    LLM_OUTPUT_COST_PER_1K: "0.015",
+  });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+async function seedEntries(count: number, daysAgo = 0): Promise<void> {
+  const baseTs = Date.now() - daysAgo * 24 * 60 * 60 * 1000;
+  for (let i = 0; i < count; i += 1) {
+    await appendEntry(env, IMEI, {
+      id: `seed-${daysAgo}-${i}`,
+      ts: baseTs - i * 60_000,
+      lat: 37.1,
+      lon: -118.5,
+      note: `seed entry ${i}`,
+      source: "drop",
+    });
+  }
+}
+
+describe("P2-06 !brief — empty FieldLog", () => {
+  test("short-circuits with canned message; LLM never called", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!brief"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["No entries to brief on."]);
+  });
+});
+
+describe("P2-06 !brief — happy path with entries", () => {
+  test("LLM called with FieldLog context; short reply hits device", async () => {
+    await seedEntries(3);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () =>
+          jsonResponse(
+            chatCompletionResponse(
+              "Logged 3 observations.\nMostly mid-day at base camp.\nWeather steady.\nNo SOS events.\nMonth-to-date $0.05.",
+            ),
+          ),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!brief"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toContain("Logged 3 observations");
+    expect(messages[0].length).toBeLessThanOrEqual(320);
+
+    // Verify the LLM was called with the seeded entries in the prompt.
+    const llmCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === "string" &&
+        (c[0].includes("openrouter.ai") || c[0].includes("/chat/completions")),
+    );
+    const reqBody = JSON.parse((llmCall![1] as RequestInit).body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = reqBody.messages.find((m) => m.role === "user")!.content;
+    expect(userMsg).toContain("seed entry 0");
+    expect(userMsg).toContain("seed entry 1");
+    expect(userMsg).toContain("seed entry 2");
+  });
+});
+
+describe("P2-06 !brief — long output email path", () => {
+  test("> 320 chars: device gets pointer; full brief routes to email", async () => {
+    await seedEntries(2);
+    const longBrief = "A".repeat(500);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse(longBrief)),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_brief_long" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!brief"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Brief sent by email."]);
+
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCall).toBeDefined();
+    const sentBody = JSON.parse((resendCall![1] as RequestInit).body as string) as {
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(sentBody.to).toBe(env.RESEND_FROM_EMAIL);
+    expect(sentBody.subject).toContain("TrailScribe brief");
+    expect(sentBody.text).toContain(longBrief);
+  });
+});
+
+describe("P2-06 !brief — custom window", () => {
+  test("`!brief 7d` includes entries within 7 days; excludes older", async () => {
+    await seedEntries(1, 0); // today
+    await seedEntries(1, 3); // 3 days ago
+    await seedEntries(1, 10); // 10 days ago
+
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse("brief output")),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!brief 7d"));
+
+    const llmCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === "string" &&
+        (c[0].includes("openrouter.ai") || c[0].includes("/chat/completions")),
+    );
+    const reqBody = JSON.parse((llmCall![1] as RequestInit).body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = reqBody.messages.find((m) => m.role === "user")!.content;
+    expect(userMsg).toContain("seed entry"); // some entries surface
+    expect(userMsg).toContain("Window: last 7d");
+    // The 10-day-old entry should be excluded — but it carries the same
+    // "seed entry 0" content as the others, so we assert the entry-count
+    // line instead.
+    expect(userMsg).toContain("Entries: 2.");
+  });
+});
+
+describe("P2-06 !brief — budget gate", () => {
+  test("daily budget exhausted: short-circuits LLM call", async () => {
+    await seedEntries(2);
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 40000, completion_tokens: 12000 },
+      env,
+    });
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!brief"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toContain("Daily AI budget reached");
+  });
+});
+
+describe("P2-06 !brief — idempotency", () => {
+  test("replay does not re-bill the LLM", async () => {
+    await seedEntries(2);
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai") || u.includes("/chat/completions"),
+        respond: () => jsonResponse(chatCompletionResponse("brief output")),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const ev = envelope("!brief", { ts: 7777 });
+    await postIpc(ev);
+    await postIpc(ev);
+
+    const llmCalls = fetchSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes("openrouter") || u.includes("/chat/completions"));
+    expect(llmCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #115 (P2-06). The first FieldLog *reader* — aggregates the last 24h (or \`Nd\` per the optional grammar slot) of FieldLog entries plus month-to-date ledger and asks the LLM for a tight 5-line summary.

## Pipeline

\`\`\`
empty FieldLog → "No entries to brief on." (no LLM cost)
budget gate
LLM (checkpointed as \`brief\`)
ledger (real OpenRouter usage)
reply ≤320 chars  OR  overflow → email (checkpointed as \`brief_overflow_email\`)
\`\`\`

Cheapest path is empty FieldLog: read once and short-circuit before the budget+LLM round. OpName union gains \`brief\` and \`brief_overflow_email\`.

## Behavior

- **Empty FieldLog within window:** \`No entries to brief on.\` — no LLM call, no ledger entry.
- **Default window:** last 24 hours.
- **Custom window:** \`!brief 7d\` (parses through \`grammar.ts\`'s P2-02 slot).
- **Short reply:** raw LLM content goes to device.
- **Long reply (>320 chars):** device gets \`Brief sent by email.\`; full content + window context routes to \`RESEND_FROM_EMAIL\`.
- **Daily token budget:** short-circuits LLM call when exhausted.
- **Replay:** LLM call once; email send once.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 277/277 (6 new, against current main)
- [ ] Real-device verification (rolls into P2-16; needs P2-05 \`!drop\` shipped first to seed FieldLog)

> Branch is based on \`main\` before #137/#138/#139/#140/#141/#142 merge. Will need a rebase to interleave the OpName union extensions; mechanical conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)