### PR TITLE
feat(commands): !share enriched email with alias resolution (P2-10)

### DIFF
--- a/src/core/commands/share.ts
+++ b/src/core/commands/share.ts
@@ -1,0 +1,137 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { reverseGeocode } from "../../adapters/location/geocode.js";
+import { sendEmail, ResendError } from "../../adapters/mail/resend.js";
+import { resolve as resolveAlias, isValidEmail } from "../addressbook.js";
+import { recordTransaction } from "../ledger.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type ShareCommand = Extract<ParsedCommand, { type: "share" }>;
+
+const SUBJECT = "TrailScribe — note from the field";
+
+/**
+ * `!share to:<addr|alias> <note>` pipeline (plan P2-10). Single-recipient
+ * variant of `!mail` with alias resolution. Reuses Phase 1's Resend adapter;
+ * the only new behavior is the address-book lookup when `to` does not look
+ * like a literal email.
+ */
+export async function handleShare(
+  cmd: ShareCommand,
+  ctx: OrchestratorContext,
+): Promise<CommandResult> {
+  const { env, imei, lat, lon, idemKey } = ctx;
+
+  let recipient: string;
+  let displayLabel: string;
+  if (cmd.to.includes("@")) {
+    if (!isValidEmail(cmd.to)) {
+      return { body: `Bad to: ${cmd.to.slice(0, 60)}` };
+    }
+    recipient = cmd.to;
+    displayLabel = truncateForReply(cmd.to);
+  } else {
+    let resolved: string[];
+    try {
+      resolved = resolveAlias(env, cmd.to);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log({ event: "share_alias_unknown", level: "warn", imei, alias: cmd.to, error: msg });
+      return { body: `Unknown alias: ${cmd.to.slice(0, 60)}` };
+    }
+    if (resolved.length === 0) {
+      return { body: `Unknown alias: ${cmd.to.slice(0, 60)}` };
+    }
+    if (resolved.length > 1) {
+      log({
+        event: "share_alias_multiple",
+        level: "warn",
+        imei,
+        alias: cmd.to,
+        count: resolved.length,
+      });
+    }
+    recipient = resolved[0];
+    displayLabel = cmd.to;
+  }
+
+  const hasGps = lat !== undefined && lon !== undefined;
+  let placeName: string | undefined;
+  if (hasGps) {
+    try {
+      placeName = await reverseGeocode(lat, lon, env);
+    } catch (err) {
+      log({
+        event: "share_geocode_failed",
+        level: "warn",
+        imei,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const body = composeBody(cmd.note, hasGps, placeName, lat, lon, env);
+
+  try {
+    await withCheckpoint(env, idemKey, "share", async () => {
+      const result = await sendEmail({ to: recipient, subject: SUBJECT, body, env });
+      return { id: result.id };
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "share_send_failed", level: "error", imei, error: msg });
+    await markFailed(env, idemKey, `share: ${msg}`);
+    if (err instanceof ResendError) {
+      return { body: `Share failed: ${msg.slice(0, 80)}` };
+    }
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  try {
+    await recordTransaction({
+      command: "share",
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "share_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (!hasGps) {
+    return { body: "Shared (no GPS)." };
+  }
+  return { body: `Shared with ${displayLabel}.` };
+}
+
+function composeBody(
+  note: string,
+  hasGps: boolean,
+  placeName: string | undefined,
+  lat: number | undefined,
+  lon: number | undefined,
+  env: OrchestratorContext["env"],
+): string {
+  const iso = new Date().toISOString();
+  if (!hasGps) {
+    return `${note}\n\n---\nFrom inReach — sent ${iso}`;
+  }
+  const mapsUrl = `${env.GOOGLE_MAPS_BASE}${lat},${lon}`;
+  const mapShareLine = env.MAPSHARE_BASE.length > 0 ? `\nMapShare: ${env.MAPSHARE_BASE}` : "";
+  return [
+    note,
+    "",
+    "---",
+    `From inReach @ ${placeName ?? "unknown"} (${lat},${lon}) — sent ${iso}`,
+    `Maps: ${mapsUrl}${mapShareLine}`,
+  ].join("\n");
+}
+
+function truncateForReply(s: string): string {
+  return s.length > 40 ? s.slice(0, 40) : s;
+}

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -49,7 +49,8 @@ export type OpName =
   | "ai"
   | "ai_overflow_email"
   | "camp"
-  | "camp_overflow_email";
+  | "camp_overflow_email"
+  | "share";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -10,6 +10,7 @@ import { handleDrop } from "./commands/drop.js";
 import { handleBrief } from "./commands/brief.js";
 import { handleAi } from "./commands/ai.js";
 import { handleCamp } from "./commands/camp.js";
+import { handleShare } from "./commands/share.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -69,6 +70,7 @@ export async function orchestrate(
     case "camp":
       return handleCamp(command, ctx);
     case "share":
+      return handleShare(command, ctx);
     case "blast":
     case "postimg":
       // Phase 2 commands parse cleanly (P2-02) but the per-command handlers

--- a/tests/p2-10-share.test.ts
+++ b/tests/p2-10-share.test.ts
@@ -1,0 +1,250 @@
+/**
+ * P2-10 — End-to-end integration tests for !share pipeline.
+ *
+ * Asserts:
+ *   - Alias path: `to:home` resolves via address book; Resend gets the right addr.
+ *   - Literal email path: `to:friend@x.com` skips the alias lookup.
+ *   - Unknown alias: rejected before any Resend call.
+ *   - Bad literal email: rejected.
+ *   - GPS path: email body has Maps link + place name.
+ *   - No-GPS path: email body has plain footer; reply is `Shared (no GPS).`.
+ *   - Idempotency: replay does not double-send.
+ *   - Ledger: 0-cost share entry.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+const LAT = 37.1682;
+const LON = -118.5891;
+
+const ADDRESS_BOOK = JSON.stringify({
+  aliases: {
+    home: "you@example.com",
+    mom: "mom@example.com",
+    all: "you@example.com,mom@example.com",
+  },
+});
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function envelope(
+  freeText: string,
+  opts: { ts?: number; gps?: { lat: number; lon: number } } = {},
+) {
+  const point = opts.gps
+    ? { latitude: opts.gps.lat, longitude: opts.gps.lon, altitude: 1000, gpsFix: 2 }
+    : { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 };
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point,
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+function makeFetchRouter(
+  routes: Array<{ match: (url: string) => boolean; respond: () => Response | Promise<Response> }>,
+) {
+  return vi.fn(async (url: URL | RequestInfo) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const r of routes) {
+      if (r.match(u)) return await r.respond();
+    }
+    throw new Error(`unmatched fetch: ${u}`);
+  });
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({ ADDRESS_BOOK_JSON: ADDRESS_BOOK });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P2-10 !share — alias resolution", () => {
+  test("alias `home` resolves to mapped email; Resend called with that recipient", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () => jsonResponse({ address: { locality: "Lake Sabrina", state: "California" } }),
+      },
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_share" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!share to:home stopped at lake", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Shared with home."]);
+
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCall).toBeDefined();
+    const sentBody = JSON.parse((resendCall![1] as RequestInit).body as string) as {
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(sentBody.to).toBe("you@example.com");
+    expect(sentBody.subject).toBe("TrailScribe — note from the field");
+    expect(sentBody.text).toContain("stopped at lake");
+    expect(sentBody.text).toContain("Lake Sabrina");
+    expect(sentBody.text).toContain(`Maps: https://www.google.com/maps/search/?api=1&query=${LAT},${LON}`);
+  });
+
+  test("unknown alias: rejected before Resend call", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!share to:nobody hello"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Unknown alias/);
+  });
+});
+
+describe("P2-10 !share — literal email", () => {
+  test("`to:friend@x.com` skips alias lookup and goes straight to Resend", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_literal" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!share to:friend@example.com hello there"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Shared (with friend@example\.com\.|\(no GPS\)\.)$/);
+
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    const sentBody = JSON.parse((resendCall![1] as RequestInit).body as string) as { to: string };
+    expect(sentBody.to).toBe("friend@example.com");
+  });
+
+  test("bad literal email: rejected", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!share to:not-an-email@ hello"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Bad to:/);
+  });
+});
+
+describe("P2-10 !share — no GPS fix", () => {
+  test("email body omits location lines; reply is `Shared (no GPS).`", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_nogps" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!share to:home no-gps test"));
+
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes("nominatim"))).toBe(false);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Shared (no GPS)."]);
+
+    const resendCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    const sentBody = JSON.parse((resendCall![1] as RequestInit).body as string) as { text: string };
+    expect(sentBody.text).toContain("From inReach — sent");
+    expect(sentBody.text).not.toContain("Maps:");
+  });
+});
+
+describe("P2-10 !share — idempotency + ledger", () => {
+  test("replay does not double-send; ledger records cmd=share at $0", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_replay" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const ev = envelope("!share to:home replay test", { ts: 4321 });
+    await postIpc(ev);
+    await postIpc(ev);
+
+    const resendCalls = fetchSpy.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCalls).toHaveLength(1);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.by_command["share"]).toEqual({ requests: 1, usd_cost: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #119 (P2-10). Single-recipient \`!mail\` variant with address-book alias resolution.

## Behavior

- \`!share to:home <note>\` — resolves \`home\` via \`ADDRESS_BOOK_JSON\`, sends enriched email to the mapped address.
- \`!share to:friend@example.com <note>\` — literal email, skips alias lookup.
- \`!share to:unknown <note>\` — \`Unknown alias: <name>\`. No Resend call.
- \`!share to:bad@ <note>\` — \`Bad to: bad@\`. No Resend call.
- **GPS path:** email body has place name + Maps link (+ MapShare line if configured); reply \`Shared with <alias-or-truncated-addr>.\`
- **No-GPS path:** plain footer; reply \`Shared (no GPS).\`
- **Replay:** Resend send hits exactly once via \`withCheckpoint('share')\`.
- **Ledger:** \`cmd: 'share', usd_cost: 0\`.

## Address book on staging + prod

\`ADDRESS_BOOK_JSON\` was provisioned this session via \`pnpm exec wrangler secret put\`. Aliases shipped:

| alias | maps to |
|---|---|
| me, home | brockamer@gmail.com |
| mom | annecbrock@gmail.com |
| sam | samebrock@gmail.com |
| oro | shiftleads@ororecovery.com |
| all | brockamer@gmail.com,annecbrock@gmail.com,samebrock@gmail.com (consumed by !blast) |

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 277/277 (against current main; will roll forward as the merge queue lands)
- [ ] Real-device verification on Mini after merge → P2-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)