### PR TITLE
feat(commands): !blast broadcast to address-book all group (P2-11)

### DIFF
--- a/src/core/commands/blast.ts
+++ b/src/core/commands/blast.ts
@@ -1,0 +1,130 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { reverseGeocode } from "../../adapters/location/geocode.js";
+import { sendEmail } from "../../adapters/mail/resend.js";
+import { resolve as resolveAlias } from "../addressbook.js";
+import { recordTransaction } from "../ledger.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type BlastCommand = Extract<ParsedCommand, { type: "blast" }>;
+
+const SUBJECT = "TrailScribe — broadcast from the field";
+const ALL_GROUP = "all";
+
+/**
+ * `!blast <note>` pipeline (plan P2-11). Resolves the `all` alias from the
+ * address book and sends one Resend call per recipient. Per-recipient errors
+ * are tolerated — one bad address does not block the rest; the device reply
+ * summarizes successes vs. failures.
+ *
+ * The full multi-send is wrapped in a single `withCheckpoint('blast')` whose
+ * cached result is the per-recipient outcome map. On retry storms, the entire
+ * blast is replayed-once at the storage layer; we don't checkpoint each
+ * recipient individually because partial-failure is part of the contract,
+ * and the operator's expectation on retry is "the same outcome as before."
+ */
+export async function handleBlast(
+  cmd: BlastCommand,
+  ctx: OrchestratorContext,
+): Promise<CommandResult> {
+  const { env, imei, lat, lon, idemKey } = ctx;
+
+  let recipients: string[];
+  try {
+    recipients = resolveAlias(env, ALL_GROUP);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "blast_no_group", level: "warn", imei, error: msg });
+    return { body: "No blast group configured." };
+  }
+  if (recipients.length === 0) {
+    return { body: "No blast group configured." };
+  }
+
+  const hasGps = lat !== undefined && lon !== undefined;
+  let placeName: string | undefined;
+  if (hasGps) {
+    try {
+      placeName = await reverseGeocode(lat, lon, env);
+    } catch (err) {
+      log({
+        event: "blast_geocode_failed",
+        level: "warn",
+        imei,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const body = composeBody(cmd.note, hasGps, placeName, lat, lon, env);
+
+  let outcome: { sent: number; failed: number };
+  try {
+    outcome = await withCheckpoint(env, idemKey, "blast", async () => {
+      let sent = 0;
+      let failed = 0;
+      for (const to of recipients) {
+        try {
+          await sendEmail({ to, subject: SUBJECT, body, env });
+          sent += 1;
+        } catch (err) {
+          failed += 1;
+          log({
+            event: "blast_send_failed",
+            level: "warn",
+            imei,
+            to,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      return { sent, failed };
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log({ event: "blast_pipeline_failed", level: "error", imei, error: msg });
+    await markFailed(env, idemKey, `blast: ${msg}`);
+    return { body: `Error: ${msg.slice(0, 80)}` };
+  }
+
+  try {
+    await recordTransaction({
+      command: "blast",
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "blast_ledger_write_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return { body: `Blasted to ${outcome.sent} (${outcome.failed} failed).` };
+}
+
+function composeBody(
+  note: string,
+  hasGps: boolean,
+  placeName: string | undefined,
+  lat: number | undefined,
+  lon: number | undefined,
+  env: OrchestratorContext["env"],
+): string {
+  const iso = new Date().toISOString();
+  if (!hasGps) {
+    return `${note}\n\n---\nFrom inReach — sent ${iso}`;
+  }
+  const mapsUrl = `${env.GOOGLE_MAPS_BASE}${lat},${lon}`;
+  const mapShareLine = env.MAPSHARE_BASE.length > 0 ? `\nMapShare: ${env.MAPSHARE_BASE}` : "";
+  return [
+    note,
+    "",
+    "---",
+    `From inReach @ ${placeName ?? "unknown"} (${lat},${lon}) — sent ${iso}`,
+    `Maps: ${mapsUrl}${mapShareLine}`,
+  ].join("\n");
+}

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -50,7 +50,8 @@ export type OpName =
   | "ai_overflow_email"
   | "camp"
   | "camp_overflow_email"
-  | "share";
+  | "share"
+  | "blast";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -11,6 +11,7 @@ import { handleBrief } from "./commands/brief.js";
 import { handleAi } from "./commands/ai.js";
 import { handleCamp } from "./commands/camp.js";
 import { handleShare } from "./commands/share.js";
+import { handleBlast } from "./commands/blast.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -72,6 +73,7 @@ export async function orchestrate(
     case "share":
       return handleShare(command, ctx);
     case "blast":
+      return handleBlast(command, ctx);
     case "postimg":
       // Phase 2 commands parse cleanly (P2-02) but the per-command handlers
       // land in P2-03..P2-11 + P2-18. Until then a real send surfaces a clear

--- a/tests/p2-11-blast.test.ts
+++ b/tests/p2-11-blast.test.ts
@@ -1,0 +1,180 @@
+/**
+ * P2-11 — End-to-end integration tests for !blast pipeline.
+ *
+ * Asserts:
+ *   - Happy path: 3-of-3 sends succeed; reply summarizes.
+ *   - Partial failure: 2-of-3 succeed; reply names the count of failures.
+ *   - No `all` group: rejected before any Resend call; reply names the gap.
+ *   - Replay: per-recipient sends not duplicated (whole blast is checkpointed).
+ *   - Ledger: 0-cost blast entry.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+const ALL_BOOK = JSON.stringify({
+  aliases: { all: "a@example.com,b@example.com,c@example.com" },
+});
+const ALL_BOOK_2 = JSON.stringify({ aliases: { all: "a@x.com,b@y.com" } });
+const NO_ALL_BOOK = JSON.stringify({ aliases: { home: "you@example.com" } });
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function envelope(freeText: string, opts: { ts?: number } = {}) {
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point: { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 },
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({ ADDRESS_BOOK_JSON: ALL_BOOK });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P2-11 !blast — happy path", () => {
+  test("3-of-3 sends succeed; reply summarizes", async () => {
+    fetchSpy = vi.fn(async (url: URL | RequestInfo) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("api.resend.com")) return jsonResponse({ id: "re_msg_blast" });
+      throw new Error(`unmatched fetch: ${u}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!blast camp ok"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Blasted to 3 (0 failed)."]);
+
+    const resendCalls = fetchSpy.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    expect(resendCalls).toHaveLength(3);
+
+    // Each recipient unique
+    const tos = resendCalls.map((c) => {
+      const body = JSON.parse((c[1] as RequestInit).body as string) as { to: string };
+      return body.to;
+    });
+    expect(new Set(tos)).toEqual(new Set(["a@example.com", "b@example.com", "c@example.com"]));
+  });
+});
+
+describe("P2-11 !blast — partial failure", () => {
+  test("2-of-3 succeed; one Resend 4xx; reply names the failure count", async () => {
+    let callCount = 0;
+    fetchSpy = vi.fn(async (url: URL | RequestInfo) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("api.resend.com")) {
+        callCount += 1;
+        if (callCount === 2) {
+          return jsonResponse({ name: "validation_error", message: "bad domain" }, 400);
+        }
+        return jsonResponse({ id: `re_msg_blast_${callCount}` });
+      }
+      throw new Error(`unmatched fetch: ${u}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!blast partial test"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["Blasted to 2 (1 failed)."]);
+  });
+});
+
+describe("P2-11 !blast — no `all` group configured", () => {
+  test("address book has no `all` alias: rejected before any Resend call", async () => {
+    env = makeTestEnv({ ADDRESS_BOOK_JSON: NO_ALL_BOOK });
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!blast hello"));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages).toEqual(["No blast group configured."]);
+  });
+});
+
+describe("P2-11 !blast — idempotency + ledger", () => {
+  test("replay does not double-send; ledger records cmd=blast at $0", async () => {
+    env = makeTestEnv({ ADDRESS_BOOK_JSON: ALL_BOOK_2 });
+    fetchSpy = vi.fn(async (url: URL | RequestInfo) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("api.resend.com")) return jsonResponse({ id: "re_msg_replay" });
+      throw new Error(`unmatched fetch: ${u}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const ev = envelope("!blast replay test", { ts: 8888 });
+    await postIpc(ev);
+    await postIpc(ev);
+
+    const resendCalls = fetchSpy.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("api.resend.com"),
+    );
+    // First call: 2 sends (one per recipient). Second call: 0 (cached blast op).
+    expect(resendCalls).toHaveLength(2);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.by_command["blast"]).toEqual({ requests: 1, usd_cost: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #118 (P2-11). Resolves the \`all\` alias from \`ADDRESS_BOOK_JSON\` and sends one Resend call per recipient. Per-recipient errors are tolerated; reply summarizes successes vs. failures.

## Behavior

- **Happy path:** 3-of-3 → \`Blasted to 3 (0 failed).\`
- **Partial failure:** one Resend 4xx → \`Blasted to 2 (1 failed).\`. Failures are logged but not retried (Garmin retry storm would re-hit good recipients otherwise).
- **No \`all\` group:** \`No blast group configured.\` No Resend calls.
- **GPS:** email body has place name + Maps link. **No-GPS:** plain footer.
- **Replay:** entire blast op is one \`withCheckpoint('blast')\`. Replay returns the cached outcome; no recipient gets a duplicate.
- **Ledger:** \`cmd: 'blast', usd_cost: 0\`.

The shipped \`all\` group on staging+prod is \`brockamer@gmail.com,annecbrock@gmail.com,samebrock@gmail.com\`. \`oro\` was deliberately left out of \`all\` (work-only). Adjust by re-running \`pnpm exec wrangler secret put ADDRESS_BOOK_JSON\` later if needed.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 275/275 (4 new, against current main)
- [ ] Real-device verification on Mini after merge → P2-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)