### PR TITLE
feat(commands): !postimg image-augmented journal post (P2-18)

### DIFF
--- a/src/adapters/publish/github-pages.ts
+++ b/src/adapters/publish/github-pages.ts
@@ -263,6 +263,243 @@ function base64Utf8(s: string): string {
   return btoa(bin);
 }
 
+/** ArrayBuffer → base64 (binary path; same Latin-1 trick as base64Utf8). */
+function base64Bytes(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+export interface PublishPostWithImageArgs extends PublishPostArgs {
+  image: {
+    bytes: ArrayBuffer;
+    mimeType: string;
+    /** Path template applied with the same slug as the post. */
+    pathTemplate: string;
+  };
+}
+
+export interface PublishPostWithImageResult extends PublishPostResult {
+  imagePath: string;
+  commitOid: string;
+}
+
+interface GraphqlCommitData {
+  data?: {
+    createCommitOnBranch?: {
+      commit?: { oid: string; url: string };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface GraphqlBranchOidData {
+  data?: {
+    repository?: {
+      ref?: { target?: { oid: string } };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+/**
+ * Atomic markdown + image commit via GitHub's GraphQL `createCommitOnBranch`
+ * mutation (P2-18). The two `additions` land in a single commit, so an
+ * interrupted run cannot leave a markdown post pointing at a missing image.
+ *
+ * Public URL derivation, slug collision handling, and frontmatter shape are
+ * inherited from `publishPost` — this function calls into the same helpers
+ * and adds an `image:` frontmatter key plus a leading `![title](/path)`
+ * markdown line so the rendered Pages site shows the image at the top.
+ */
+export async function publishPostWithImage(
+  args: PublishPostWithImageArgs,
+): Promise<PublishPostWithImageResult> {
+  const { title, haiku, body, lat, lon, placeName, weather, env, image } = args;
+  const now = (args.now ?? (() => new Date()))();
+
+  const yyyy = String(now.getUTCFullYear());
+  const mm = pad2(now.getUTCMonth() + 1);
+  const dd = pad2(now.getUTCDate());
+
+  const baseSlug = slugify(title, now);
+  const { path, slug: finalSlug } = await findFreePath(env, env.JOURNAL_POST_PATH_TEMPLATE, {
+    yyyy,
+    mm,
+    dd,
+    baseSlug,
+  });
+
+  const ext = extensionForMime(image.mimeType);
+  const imagePath = image.pathTemplate
+    .replaceAll("{yyyy}", yyyy)
+    .replaceAll("{mm}", mm)
+    .replaceAll("{dd}", dd)
+    .replaceAll("{slug}", finalSlug)
+    .replaceAll("{ext}", ext);
+
+  const markdown = renderMarkdownWithImage({
+    title,
+    haiku,
+    body,
+    date: now.toISOString(),
+    lat,
+    lon,
+    placeName,
+    weather,
+    imagePath,
+  });
+
+  const [owner, repo] = splitRepo(env.GITHUB_JOURNAL_REPO);
+  const branch = env.GITHUB_JOURNAL_BRANCH;
+
+  const expectedHeadOid = await fetchBranchOid(env, owner, repo, branch);
+
+  const mutationVars = {
+    input: {
+      branch: { repositoryNameWithOwner: env.GITHUB_JOURNAL_REPO, branchName: branch },
+      message: { headline: `trailscribe: ${title}` },
+      expectedHeadOid,
+      fileChanges: {
+        additions: [
+          { path, contents: base64Utf8(markdown) },
+          { path: imagePath, contents: base64Bytes(image.bytes) },
+        ],
+      },
+    },
+  };
+
+  const mutation = `mutation ($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit { oid url }
+  }
+}`;
+
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: githubHeaders(env),
+    body: JSON.stringify({ query: mutation, variables: mutationVars }),
+  });
+
+  if (!res.ok) {
+    const message = await readErrorMessage(res);
+    throw new PublishError({
+      status: res.status,
+      message: `GraphQL createCommitOnBranch HTTP ${res.status}: ${message}`,
+    });
+  }
+
+  const json = (await res.json()) as GraphqlCommitData;
+  if (json.errors && json.errors.length > 0) {
+    throw new PublishError({
+      status: 0,
+      message: `GraphQL createCommitOnBranch errors: ${json.errors.map((e) => e.message).join("; ")}`,
+    });
+  }
+  const commit = json.data?.createCommitOnBranch?.commit;
+  if (!commit) {
+    throw new PublishError({
+      status: 0,
+      message: "GraphQL createCommitOnBranch returned no commit",
+    });
+  }
+
+  const url = renderUrl(env.JOURNAL_URL_TEMPLATE, { yyyy, mm, dd, slug: finalSlug });
+  return {
+    url,
+    path,
+    sha: commit.oid,
+    imagePath,
+    commitOid: commit.oid,
+  };
+}
+
+async function fetchBranchOid(
+  env: Env,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<string> {
+  const query = `query ($owner: String!, $repo: String!, $branch: String!) {
+  repository(owner: $owner, name: $repo) {
+    ref(qualifiedName: $branch) {
+      target { ... on Commit { oid } }
+    }
+  }
+}`;
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: githubHeaders(env),
+    body: JSON.stringify({
+      query,
+      variables: { owner, repo, branch: `refs/heads/${branch}` },
+    }),
+  });
+  if (!res.ok) {
+    const message = await readErrorMessage(res);
+    throw new PublishError({
+      status: res.status,
+      message: `GraphQL branch oid HTTP ${res.status}: ${message}`,
+    });
+  }
+  const json = (await res.json()) as GraphqlBranchOidData;
+  const oid = json.data?.repository?.ref?.target?.oid;
+  if (!oid) {
+    throw new PublishError({
+      status: 0,
+      message: `GraphQL branch oid: branch '${branch}' not found on ${owner}/${repo}`,
+    });
+  }
+  return oid;
+}
+
+function splitRepo(nameWithOwner: string): [string, string] {
+  const [owner, repo] = nameWithOwner.split("/");
+  if (!owner || !repo) {
+    throw new PublishError({
+      status: 0,
+      message: `GITHUB_JOURNAL_REPO must be 'owner/repo', got '${nameWithOwner}'`,
+    });
+  }
+  return [owner, repo];
+}
+
+function extensionForMime(mimeType: string): string {
+  const m = mimeType.toLowerCase();
+  if (m.includes("png")) return "png";
+  if (m.includes("jpeg") || m.includes("jpg")) return "jpg";
+  if (m.includes("webp")) return "webp";
+  if (m.includes("gif")) return "gif";
+  return "img";
+}
+
+interface RenderArgsWithImage extends RenderArgs {
+  imagePath: string;
+}
+
+function renderMarkdownWithImage(a: RenderArgsWithImage): string {
+  const lines: string[] = ["---"];
+  lines.push(`title: ${quoteYaml(a.title)}`);
+  lines.push(`date: ${a.date}`);
+  lines.push(`image: /${a.imagePath}`);
+  if (a.lat !== undefined && a.lon !== undefined) {
+    const place = a.placeName !== undefined ? `, place: ${quoteYaml(a.placeName)}` : "";
+    lines.push(`location: { lat: ${a.lat}, lon: ${a.lon}${place} }`);
+  }
+  if (a.weather !== undefined) {
+    lines.push(`weather: ${quoteYaml(a.weather)}`);
+  }
+  lines.push("tags: [trailscribe]");
+  lines.push("---");
+  lines.push(`![${a.title}](/${a.imagePath})`);
+  lines.push("");
+  lines.push(a.haiku);
+  lines.push("");
+  lines.push(a.body);
+  return lines.join("\n");
+}
+
 async function readErrorMessage(res: Response): Promise<string> {
   try {
     const body = (await res.json()) as ContentsApiErrorBody;

--- a/src/core/commands/postimg.ts
+++ b/src/core/commands/postimg.ts
@@ -1,0 +1,256 @@
+import type { CommandResult, ParsedCommand } from "../types.js";
+import type { OrchestratorContext } from "../orchestrator.js";
+import { reverseGeocode } from "../../adapters/location/geocode.js";
+import { currentWeather } from "../../adapters/location/weather.js";
+import { generateNarrative } from "../narrative.js";
+import { generateImage, ImageGenError } from "../../adapters/ai/replicate.js";
+import { buildImagePrompt } from "../imageprompt.js";
+import { publishPost, publishPostWithImage } from "../../adapters/publish/github-pages.js";
+import { recordTransaction, recordImageTransaction } from "../ledger.js";
+import { appendEvent } from "../context.js";
+import { withCheckpoint, markFailed } from "../idempotency.js";
+import { BUDGET_REJECTION_MESSAGE, ESTIMATED_POST_TOKENS, checkBudget } from "../budget.js";
+import { log } from "../../adapters/logging/worker-logs.js";
+
+type PostImgCommand = Extract<ParsedCommand, { type: "postimg" }>;
+
+/**
+ * `!postimg <caption>` pipeline (plan P2-18). Mirrors `!post` with an
+ * image-gen step inserted before the journal commit. The markdown post and
+ * the binary image are committed *atomically* via GitHub's GraphQL
+ * `createCommitOnBranch` mutation so an interrupted run cannot leave a
+ * markdown post pointing at a missing image.
+ *
+ * Pipeline:
+ *   1. budget gate (text LLM)
+ *   2. enrich (geocode + weather, GPS-conditional)
+ *   3. narrative LLM (checkpointed as 'narrative')
+ *   4. image-gen (checkpointed as 'image'; failure → text-only fallback)
+ *   5. atomic commit markdown + image (checkpointed as 'publish')
+ *   6. ledger (text + image, recorded separately so existing `!cost`
+ *      semantics stay intact and the breakout reply lights up)
+ *   7. context append + reply
+ */
+export async function handlePostImg(
+  cmd: PostImgCommand,
+  ctx: OrchestratorContext,
+): Promise<CommandResult> {
+  const { env, imei, lat, lon, idemKey } = ctx;
+
+  const budget = await checkBudget(env, ESTIMATED_POST_TOKENS);
+  if (!budget.allowed) {
+    log({ event: "postimg_budget_rejected", level: "warn", imei, remaining: budget.remaining });
+    return { body: BUDGET_REJECTION_MESSAGE };
+  }
+
+  const hasGps = lat !== undefined && lon !== undefined;
+  let placeName: string | undefined;
+  let weather: string | undefined;
+  if (hasGps) {
+    const [placeR, wxR] = await Promise.allSettled([
+      reverseGeocode(lat, lon, env),
+      currentWeather(lat, lon, env),
+    ]);
+    if (placeR.status === "fulfilled") placeName = placeR.value;
+    if (wxR.status === "fulfilled") weather = wxR.value;
+  }
+
+  let narrative: Awaited<ReturnType<typeof generateNarrative>>;
+  try {
+    narrative = await withCheckpoint(env, idemKey, "narrative", () =>
+      generateNarrative({
+        note: cmd.caption,
+        lat,
+        lon,
+        placeName,
+        weather,
+        env,
+      }),
+    );
+  } catch (err) {
+    return failPipeline(env, idemKey, "narrative", err, imei);
+  }
+
+  // Image-gen step. Failure here drops to text-only fallback so we don't
+  // lose the operator's caption — the journal entry still lands, just
+  // without an illustration.
+  //
+  // Bytes are stored as base64 in the checkpoint so withCheckpoint's JSON
+  // round-trip survives. On replay we decode back to ArrayBuffer; since the
+  // downstream publish step is also checkpointed we'd usually short-circuit
+  // before re-using bytes, but we keep them recoverable for safety.
+  type ImageOpResult =
+    | { ok: true; bytesB64: string; mimeType: string; costUsd: number; model: string }
+    | { ok: false; error: string };
+
+  const imagePrompt = buildImagePrompt({
+    caption: cmd.caption,
+    place: placeName,
+    lat,
+    lon,
+    weather,
+  });
+
+  const imageResult: ImageOpResult = await withCheckpoint(env, idemKey, "image", async () => {
+    try {
+      const r = await generateImage({ prompt: imagePrompt, env });
+      return {
+        ok: true as const,
+        bytesB64: arrayBufferToBase64(r.bytes),
+        mimeType: r.mimeType,
+        costUsd: r.costUsd,
+        model: r.model,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log({
+        event: "image_gen_failed",
+        level: "error",
+        imei,
+        error: msg,
+        providerResponse: err instanceof ImageGenError ? err.providerResponse : undefined,
+      });
+      return { ok: false as const, error: msg };
+    }
+  });
+
+  let imagePayload:
+    | { bytes: ArrayBuffer; mimeType: string; costUsd: number; model: string }
+    | undefined;
+  if (imageResult.ok) {
+    imagePayload = {
+      bytes: base64ToArrayBuffer(imageResult.bytesB64),
+      mimeType: imageResult.mimeType,
+      costUsd: imageResult.costUsd,
+      model: imageResult.model,
+    };
+  }
+
+  let publishResult: { url: string; path: string; sha: string };
+  let imageCommitted = false;
+  try {
+    if (imageResult.ok && imagePayload !== undefined) {
+      publishResult = await withCheckpoint(env, idemKey, "publish", () =>
+        publishPostWithImage({
+          title: narrative.title,
+          haiku: narrative.haiku,
+          body: narrative.body,
+          lat,
+          lon,
+          placeName,
+          weather,
+          env,
+          image: {
+            bytes: imagePayload!.bytes,
+            mimeType: imagePayload!.mimeType,
+            pathTemplate: env.JOURNAL_IMAGE_PATH_TEMPLATE,
+          },
+        }),
+      );
+      imageCommitted = true;
+    } else {
+      // Image-gen failed OR this is a replay where we lost the bytes; either
+      // way, fall back to a plain text-only commit so the operator's caption
+      // still lands. (On a clean replay, the publish op's withCheckpoint
+      // would already have a cached value either way.)
+      publishResult = await withCheckpoint(env, idemKey, "publish", () =>
+        publishPost({
+          title: narrative.title,
+          haiku: narrative.haiku,
+          body: narrative.body,
+          lat,
+          lon,
+          placeName,
+          weather,
+          env,
+        }),
+      );
+    }
+  } catch (err) {
+    return failPipeline(env, idemKey, "publish", err, imei);
+  }
+
+  // Ledger. Text spend always recorded; image spend only on success.
+  try {
+    await recordTransaction({
+      command: "postimg",
+      usage: narrative.usage,
+      env,
+    });
+  } catch (err) {
+    log({
+      event: "postimg_ledger_text_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  if (imageResult.ok && imagePayload !== undefined) {
+    try {
+      await recordImageTransaction({
+        command: "postimg",
+        usdCost: imagePayload.costUsd,
+        env,
+      });
+    } catch (err) {
+      log({
+        event: "postimg_ledger_image_failed",
+        level: "warn",
+        imei,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  try {
+    await appendEvent(
+      imei,
+      {
+        timestamp: Date.now(),
+        lat,
+        lon,
+        command_type: "postimg",
+        free_text: cmd.caption,
+      },
+      env,
+    );
+  } catch (err) {
+    log({
+      event: "postimg_context_append_failed",
+      level: "warn",
+      imei,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const baseReply = `Posted: ${narrative.title} · ${publishResult.url}`;
+  const body = imageCommitted ? baseReply : `${baseReply} (image gen failed; text-only)`;
+  return { body };
+}
+
+async function failPipeline(
+  env: OrchestratorContext["env"],
+  idemKey: string,
+  step: string,
+  err: unknown,
+  imei: string,
+): Promise<CommandResult> {
+  const msg = err instanceof Error ? err.message : String(err);
+  log({ event: `postimg_${step}_failed`, level: "error", imei, error: msg });
+  await markFailed(env, idemKey, `${step}: ${msg}`);
+  return { body: `Error: ${msg.slice(0, 80)}` };
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+  return out.buffer;
+}

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -51,7 +51,8 @@ export type OpName =
   | "camp"
   | "camp_overflow_email"
   | "share"
-  | "blast";
+  | "blast"
+  | "image";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -12,6 +12,7 @@ import { handleAi } from "./commands/ai.js";
 import { handleCamp } from "./commands/camp.js";
 import { handleShare } from "./commands/share.js";
 import { handleBlast } from "./commands/blast.js";
+import { handlePostImg } from "./commands/postimg.js";
 
 export interface OrchestratorContext {
   env: Env;
@@ -75,10 +76,7 @@ export async function orchestrate(
     case "blast":
       return handleBlast(command, ctx);
     case "postimg":
-      // Phase 2 commands parse cleanly (P2-02) but the per-command handlers
-      // land in P2-03..P2-11 + P2-18. Until then a real send surfaces a clear
-      // device-visible error via app.ts's orchestrate-error reply path.
-      throw new Error(`!${command.type} not yet implemented`);
+      return handlePostImg(command, ctx);
   }
 }
 
@@ -105,7 +103,11 @@ function helpText(): string {
 function formatCostBody(snap: LedgerSnapshot): string {
   const totalTokens = snap.prompt_tokens + snap.completion_tokens;
   const tokensK = (totalTokens / 1000).toFixed(1);
-  const cost = snap.usd_cost.toFixed(2);
+  const textCost = snap.usd_cost.toFixed(2);
   const sinceDate = `${snap.period}-01`;
-  return `${snap.requests} req · ${tokensK}k tok · $${cost} (since ${sinceDate})`;
+  const imageCost = snap.image_usd_cost ?? 0;
+  if (imageCost > 0) {
+    return `${snap.requests} req · ${tokensK}k tok · $${textCost} + $${imageCost.toFixed(2)} img (since ${sinceDate})`;
+  }
+  return `${snap.requests} req · ${tokensK}k tok · $${textCost} (since ${sinceDate})`;
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,6 +34,7 @@ export interface Env {
   IMAGE_PROVIDER: string;
   IMAGE_MODEL: string;
   IMAGE_COST_PER_CALL_USD: string;
+  JOURNAL_IMAGE_PATH_TEMPLATE: string;
 
   // Secrets (Wrangler Secrets)
   GARMIN_INBOUND_TOKEN: string;
@@ -92,6 +93,7 @@ export const EnvSchema = z.object({
   IMAGE_PROVIDER: z.enum(["replicate"]),
   IMAGE_MODEL: z.string().min(1),
   IMAGE_COST_PER_CALL_USD: z.string(),
+  JOURNAL_IMAGE_PATH_TEMPLATE: z.string().min(1),
 
   GARMIN_INBOUND_TOKEN: z.string().min(16),
   GARMIN_IPC_INBOUND_API_KEY: z.string().min(8),

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -81,6 +81,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     IMAGE_PROVIDER: "replicate",
     IMAGE_MODEL: "black-forest-labs/flux-schnell",
     IMAGE_COST_PER_CALL_USD: "0.003",
+    JOURNAL_IMAGE_PATH_TEMPLATE: "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}",
 
     GARMIN_INBOUND_TOKEN: "test-bearer-token-abcdef0123456789",
     GARMIN_IPC_INBOUND_API_KEY: "test-api-key-abcd",

--- a/tests/p2-18-postimg.test.ts
+++ b/tests/p2-18-postimg.test.ts
@@ -1,0 +1,359 @@
+/**
+ * P2-18 — End-to-end integration tests for !postimg pipeline.
+ *
+ * Asserts:
+ *   - Happy path: enrich → narrative → image-gen → atomic GraphQL commit →
+ *     reply with journal URL. Single GraphQL mutation includes both the
+ *     markdown post and the image binary.
+ *   - Image-gen failure: falls back to text-only Contents API commit; reply
+ *     notes the fallback; no image ledger entry.
+ *   - Replay: image-gen called once across two webhook retries; commit happens
+ *     once; ledger image entry recorded once.
+ *   - !cost breakout: with image_usd_cost > 0, the !cost reply formats both
+ *     axes.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { makeApp } from "../src/app.js";
+import { makeTestEnv } from "./helpers/env.js";
+import type { Env } from "../src/env.js";
+import { monthlyTotals, recordTransaction, recordImageTransaction } from "../src/core/ledger.js";
+
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+
+vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
+  sendReply: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+const sendReplyMock = vi.mocked(sendReply);
+
+let app: ReturnType<typeof makeApp>;
+let env: Env;
+let fetchSpy: ReturnType<typeof vi.fn>;
+const originalFetch = globalThis.fetch;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+const LAT = 37.1682;
+const LON = -118.5891;
+
+function jsonResponse(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function imageResponse(): Response {
+  // Tiny 1x1 PNG-ish bytes.
+  const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  return new Response(bytes, {
+    status: 200,
+    headers: { "content-type": "image/webp" },
+  });
+}
+
+function narrativeResponse() {
+  return {
+    id: "chatcmpl-test",
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: JSON.stringify({
+            title: "Sabrina Sunset",
+            haiku: "alpenglow on stone\nthin air, an unspoken vow\ngranite holds the night",
+            body: "Light fading on the eastern Sierra. Camp set, water filtered.",
+          }),
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 100, completion_tokens: 80, total_tokens: 180 },
+  };
+}
+
+function envelope(
+  freeText: string,
+  opts: { ts?: number; gps?: { lat: number; lon: number } } = {},
+) {
+  const point = opts.gps
+    ? { latitude: opts.gps.lat, longitude: opts.gps.lon, altitude: 1000, gpsFix: 2 }
+    : { latitude: 0, longitude: 0, altitude: 0, gpsFix: 0 };
+  return {
+    Version: "2.0",
+    Events: [
+      {
+        imei: "123456789012345",
+        messageCode: 3,
+        freeText,
+        timeStamp: opts.ts ?? 1700000000000,
+        point,
+      },
+    ],
+  };
+}
+
+async function postIpc(body: unknown): Promise<Response> {
+  return app.request(
+    "/garmin/ipc",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-outbound-auth-token": env.GARMIN_INBOUND_TOKEN,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+beforeEach(() => {
+  app = makeApp();
+  env = makeTestEnv({
+    LLM_INPUT_COST_PER_1K: "0.003",
+    LLM_OUTPUT_COST_PER_1K: "0.015",
+  });
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("P2-18 !postimg — happy path", () => {
+  test("atomic GraphQL commit: markdown + image in a single mutation", async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    fetchSpy = vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      fetchCalls.push({ url: u, init });
+      if (u.includes("nominatim")) {
+        return jsonResponse({ address: { locality: "Lake Sabrina", state: "California" } });
+      }
+      if (u.includes("api.open-meteo.com")) {
+        return jsonResponse({
+          current: { temperature_2m: 42, wind_speed_10m: 8, weather_code: 0 },
+        });
+      }
+      if (u.includes("openrouter.ai") || u.includes("/chat/completions")) {
+        return jsonResponse(narrativeResponse());
+      }
+      if (u.includes("api.replicate.com") && u.endsWith("predictions")) {
+        return jsonResponse({
+          id: "pred_123",
+          status: "succeeded",
+          output: "https://replicate.delivery/output/img-123.webp",
+        });
+      }
+      if (u.includes("replicate.delivery/output")) {
+        return imageResponse();
+      }
+      // findFreePath probes Contents API for slug collision; 404 = free.
+      if (u.includes("api.github.com/repos/") && u.includes("?ref=")) {
+        return new Response("not found", { status: 404 });
+      }
+      if (u.includes("api.github.com/graphql")) {
+        // Body distinguishes the branch-oid query from the createCommit mutation.
+        const reqBody = JSON.parse((init?.body as string) ?? "{}") as {
+          query: string;
+          variables?: unknown;
+        };
+        if (reqBody.query.includes("createCommitOnBranch")) {
+          return jsonResponse({
+            data: {
+              createCommitOnBranch: {
+                commit: { oid: "abc123commit", url: "https://github.com/x/y/commit/abc" },
+              },
+            },
+          });
+        }
+        return jsonResponse({
+          data: { repository: { ref: { target: { oid: "deadbeefoid" } } } },
+        });
+      }
+      throw new Error(`unmatched fetch: ${u}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!postimg sunset at sabrina", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^Posted: Sabrina Sunset · /);
+    expect(messages[0]).not.toContain("image gen failed");
+
+    // The createCommit mutation carries TWO additions in a single request.
+    const commitCall = fetchCalls.find(
+      (c) => c.url.includes("api.github.com/graphql") &&
+        typeof c.init?.body === "string" &&
+        c.init.body.includes("createCommitOnBranch"),
+    );
+    expect(commitCall).toBeDefined();
+    const commitBody = JSON.parse(commitCall!.init!.body as string) as {
+      variables: { input: { fileChanges: { additions: Array<{ path: string }> } } };
+    };
+    const additions = commitBody.variables.input.fileChanges.additions;
+    expect(additions).toHaveLength(2);
+    const paths = additions.map((a) => a.path);
+    expect(paths.some((p) => p.startsWith("_posts/") && p.endsWith(".md"))).toBe(true);
+    expect(paths.some((p) => p.startsWith("_images/") && p.endsWith(".webp"))).toBe(true);
+    // Markdown and image share the same slug + date — atomic-commit guarantee.
+    const mdPath = paths.find((p) => p.endsWith(".md"))!;
+    const imgPath = paths.find((p) => p.endsWith(".webp"))!;
+    const slugFromMd = mdPath.replace(/^_posts\//, "").replace(/\.md$/, "");
+    const slugFromImg = imgPath.replace(/^_images\//, "").replace(/\.webp$/, "");
+    expect(slugFromMd).toBe(slugFromImg);
+
+    // Ledger captured both axes.
+    const snap = await monthlyTotals(env);
+    expect(snap.by_command["postimg"].requests).toBe(1);
+    expect(snap.image_requests).toBe(1);
+    expect(snap.image_usd_cost).toBeCloseTo(0.003, 5);
+  });
+});
+
+describe("P2-18 !postimg — image-gen failure fallback", () => {
+  test("falls back to text-only Contents API commit; reply notes the fallback", async () => {
+    fetchSpy = vi.fn(async (url: URL | RequestInfo) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("nominatim")) {
+        return jsonResponse({ address: { locality: "Lake Sabrina", state: "California" } });
+      }
+      if (u.includes("api.open-meteo.com")) {
+        return jsonResponse({ current: { temperature_2m: 42, weather_code: 0 } });
+      }
+      if (u.includes("openrouter.ai") || u.includes("/chat/completions")) {
+        return jsonResponse(narrativeResponse());
+      }
+      if (u.includes("api.replicate.com") && u.endsWith("predictions")) {
+        return new Response("upstream timeout", { status: 502 });
+      }
+      // Contents API path (text-only fallback).
+      if (u.includes("api.github.com/repos/")) {
+        if (u.includes("?ref=")) {
+          return new Response("not found", { status: 404 }); // findFreePath
+        }
+        return jsonResponse({
+          content: { sha: "fileSha", path: "_posts/x.md", html_url: "x" },
+          commit: { sha: "commitSha" },
+        });
+      }
+      throw new Error(`unmatched fetch: ${u}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!postimg fallback test", { gps: { lat: LAT, lon: LON } }));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toContain("image gen failed; text-only");
+
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    // No GraphQL mutation in the fallback path.
+    expect(calls.some((u) => u.includes("api.github.com/graphql"))).toBe(false);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.image_requests ?? 0).toBe(0);
+  });
+});
+
+describe("P2-18 !postimg — idempotency replay", () => {
+  test("image-gen and commit each run exactly once across two retries", async () => {
+    let imagePredictions = 0;
+    let commitMutations = 0;
+    fetchSpy = vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("nominatim")) {
+        return jsonResponse({ address: { locality: "Lake Sabrina", state: "California" } });
+      }
+      if (u.includes("api.open-meteo.com")) {
+        return jsonResponse({ current: { temperature_2m: 42, weather_code: 0 } });
+      }
+      if (u.includes("openrouter.ai") || u.includes("/chat/completions")) {
+        return jsonResponse(narrativeResponse());
+      }
+      if (u.includes("api.replicate.com") && u.endsWith("predictions")) {
+        imagePredictions += 1;
+        return jsonResponse({
+          id: `pred_${imagePredictions}`,
+          status: "succeeded",
+          output: "https://replicate.delivery/output/img.webp",
+        });
+      }
+      if (u.includes("replicate.delivery/output")) return imageResponse();
+      // findFreePath probes Contents API for slug collision; 404 = free.
+      if (u.includes("api.github.com/repos/") && u.includes("?ref=")) {
+        return new Response("not found", { status: 404 });
+      }
+      if (u.includes("api.github.com/graphql")) {
+        const reqBody = JSON.parse((init?.body as string) ?? "{}") as { query: string };
+        if (reqBody.query.includes("createCommitOnBranch")) {
+          commitMutations += 1;
+          return jsonResponse({
+            data: {
+              createCommitOnBranch: {
+                commit: { oid: "abc", url: "https://github.com/x/y/commit/abc" },
+              },
+            },
+          });
+        }
+        return jsonResponse({ data: { repository: { ref: { target: { oid: "headoid" } } } } });
+      }
+      throw new Error(`unmatched fetch: ${u}`);
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const ev = envelope("!postimg replay test", { ts: 4242, gps: { lat: LAT, lon: LON } });
+    await postIpc(ev);
+    await postIpc(ev);
+
+    expect(imagePredictions).toBe(1);
+    expect(commitMutations).toBe(1);
+
+    const snap = await monthlyTotals(env);
+    expect(snap.image_requests).toBe(1);
+  });
+});
+
+describe("P2-18 — !cost breakout", () => {
+  test("image entries present → !cost reply includes image axis", async () => {
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 1000, completion_tokens: 500 },
+      env: makeTestEnv({
+        ...env,
+        LLM_INPUT_COST_PER_1K: "0.10",
+        LLM_OUTPUT_COST_PER_1K: "0.30",
+      }),
+    });
+    Object.assign(env, { LLM_INPUT_COST_PER_1K: "0.10", LLM_OUTPUT_COST_PER_1K: "0.30" });
+    await recordImageTransaction({ command: "postimg", usdCost: 0.03, env });
+
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch for !cost");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!cost"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(
+      /^1 req · 1\.5k tok · \$0\.25 \+ \$0\.03 img \(since \d{4}-\d{2}-01\)$/,
+    );
+  });
+
+  test("no image entries → !cost reply preserves Phase 1 format", async () => {
+    fetchSpy = vi.fn(async () => {
+      throw new Error("should not have called fetch for !cost");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!cost"));
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages[0]).toMatch(/^0 req · 0\.0k tok · \$0\.00 \(since \d{4}-\d{2}-01\)$/);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,6 +34,7 @@ JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{
 IMAGE_PROVIDER = "replicate"
 IMAGE_MODEL = "black-forest-labs/flux-schnell"
 IMAGE_COST_PER_CALL_USD = "0.003"
+JOURNAL_IMAGE_PATH_TEMPLATE = "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
 
 # KV namespaces — provisioned per env (dev main + dev preview + staging + production).
 # To recreate from scratch: `wrangler kv namespace create <BINDING> [--preview | --env <env>]`.
@@ -104,6 +105,7 @@ JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{
 IMAGE_PROVIDER = "replicate"
 IMAGE_MODEL = "black-forest-labs/flux-schnell"
 IMAGE_COST_PER_CALL_USD = "0.003"
+JOURNAL_IMAGE_PATH_TEMPLATE = "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
 
 [[env.staging.kv_namespaces]]
 binding = "TS_IDEMPOTENCY"
@@ -151,6 +153,7 @@ JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{
 IMAGE_PROVIDER = "replicate"
 IMAGE_MODEL = "black-forest-labs/flux-schnell"
 IMAGE_COST_PER_CALL_USD = "0.003"
+JOURNAL_IMAGE_PATH_TEMPLATE = "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
 
 [[env.production.kv_namespaces]]
 binding = "TS_IDEMPOTENCY"


### PR DESCRIPTION
## Summary

Closes #125 (P2-18). Mirrors \`!post\` with an image-gen step inserted before the journal commit. The markdown post and the binary image commit **atomically** via GitHub's GraphQL \`createCommitOnBranch\` mutation, so an interrupted run cannot leave a markdown post pointing at a missing image.

## Pipeline

\`\`\`
budget gate
enrich (geocode + weather)
narrative LLM      (checkpointed as 'narrative')
image-gen          (checkpointed as 'image' — bytes stored as base64)
atomic commit      (checkpointed as 'publish'; GraphQL createCommitOnBranch)
ledger text + image (recorded separately so existing !cost stays unchanged)
context append
reply: "Posted: <title> · <url>"  (or "... (image gen failed; text-only)")
\`\`\`

## Atomic-commit upgrade

\`publishPost\` (used by \`!post\`) keeps using the existing Contents API path —
unchanged. \`publishPostWithImage\` is new and uses a single GraphQL
\`createCommitOnBranch\` mutation with two \`fileChanges.additions\`:
markdown at \`_posts/...\` and image at \`_images/...\` with the same slug. The
mutation returns one commit oid covering both files.

\`expectedHeadOid\` is fetched immediately before the mutation; concurrent-push
conflicts surface as \`PublishError\` and the operator's retry picks a fresh oid.

## Image-gen failure fallback

When the Replicate call fails (network, 5xx, malformed prediction), the handler
logs \`image_gen_failed\` and falls back to the existing \`publishPost\`
Contents API path. The operator's caption still lands in the journal; reply
notes \`(image gen failed; text-only)\`.

## !cost breakout

When \`image_usd_cost > 0\`, the \`!cost\` reply now includes the image axis:

\`\`\`
1 req · 1.5k tok · $0.25 + $0.03 img (since 2026-04-01)
\`\`\`

When no image entries exist, format is unchanged from Phase 1 (no test regression).

## Replay safety

Image bytes are cached as **base64 string** inside the \`image\` checkpoint —
\`withCheckpoint\` JSON-roundtrips its return value, and ArrayBuffer can't
survive that. Decoding back to ArrayBuffer happens after the checkpoint reads.
The replay test asserts exactly one image-gen call and exactly one commit
mutation across two webhook deliveries.

## Env additions

- \`JOURNAL_IMAGE_PATH_TEMPLATE\` (var, not secret) — default
  \`_images/{yyyy}-{mm}-{dd}-{slug}.{ext}\` in all three wrangler env stanzas.
- \`IMAGE_API_KEY\` already provisioned this session by the operator.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 276/276 (5 new, against current main)
- [x] Atomic-commit assertion: single GraphQL mutation, two file additions, slugs match
- [x] Image-gen failure → text-only fallback path covered
- [x] Replay: 1 image-gen call + 1 commit mutation across 2 webhook posts
- [x] !cost breakout asserts both formats
- [ ] Real-device verification on Mini after merge → P2-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)