### PR TITLE
fix(postimg): commit images to assets/images/ so Jekyll serves them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ plans/                          # per-milestone sprint plans (active: phase-2-ex
 - `IMAGE_PROVIDER` — `replicate` for α (P2-17; `!postimg`)
 - `IMAGE_MODEL` — e.g. `black-forest-labs/flux-schnell`
 - `IMAGE_COST_PER_CALL_USD` — ledger pricing for image-gen; default `0.01`
-- `JOURNAL_IMAGE_PATH_TEMPLATE` — e.g. `_images/{yyyy}-{mm}-{dd}-{slug}.{ext}` (commits the binary alongside the markdown post)
+- `JOURNAL_IMAGE_PATH_TEMPLATE` — e.g. `assets/images/{yyyy}-{mm}-{dd}-{slug}.{ext}` (commits the binary alongside the markdown post; non-underscore so Jekyll serves it)
 
 ## Garmin IPC quick-ref (authoritative sources in `materials/`)
 

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -81,7 +81,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     IMAGE_PROVIDER: "replicate",
     IMAGE_MODEL: "black-forest-labs/flux-schnell",
     IMAGE_COST_PER_CALL_USD: "0.003",
-    JOURNAL_IMAGE_PATH_TEMPLATE: "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}",
+    JOURNAL_IMAGE_PATH_TEMPLATE: "assets/images/{yyyy}-{mm}-{dd}-{slug}.{ext}",
 
     GARMIN_INBOUND_TOKEN: "test-bearer-token-abcdef0123456789",
     GARMIN_IPC_INBOUND_API_KEY: "test-api-key-abcd",

--- a/tests/p2-18-postimg.test.ts
+++ b/tests/p2-18-postimg.test.ts
@@ -200,12 +200,12 @@ describe("P2-18 !postimg — happy path", () => {
     expect(additions).toHaveLength(2);
     const paths = additions.map((a) => a.path);
     expect(paths.some((p) => p.startsWith("_posts/") && p.endsWith(".md"))).toBe(true);
-    expect(paths.some((p) => p.startsWith("_images/") && p.endsWith(".webp"))).toBe(true);
+    expect(paths.some((p) => p.startsWith("assets/images/") && p.endsWith(".webp"))).toBe(true);
     // Markdown and image share the same slug + date — atomic-commit guarantee.
     const mdPath = paths.find((p) => p.endsWith(".md"))!;
     const imgPath = paths.find((p) => p.endsWith(".webp"))!;
     const slugFromMd = mdPath.replace(/^_posts\//, "").replace(/\.md$/, "");
-    const slugFromImg = imgPath.replace(/^_images\//, "").replace(/\.webp$/, "");
+    const slugFromImg = imgPath.replace(/^assets\/images\//, "").replace(/\.webp$/, "");
     expect(slugFromMd).toBe(slugFromImg);
 
     // Ledger captured both axes.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,7 +34,7 @@ JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{
 IMAGE_PROVIDER = "replicate"
 IMAGE_MODEL = "black-forest-labs/flux-schnell"
 IMAGE_COST_PER_CALL_USD = "0.003"
-JOURNAL_IMAGE_PATH_TEMPLATE = "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
+JOURNAL_IMAGE_PATH_TEMPLATE = "assets/images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
 
 # KV namespaces — provisioned per env (dev main + dev preview + staging + production).
 # To recreate from scratch: `wrangler kv namespace create <BINDING> [--preview | --env <env>]`.
@@ -105,7 +105,7 @@ JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{
 IMAGE_PROVIDER = "replicate"
 IMAGE_MODEL = "black-forest-labs/flux-schnell"
 IMAGE_COST_PER_CALL_USD = "0.003"
-JOURNAL_IMAGE_PATH_TEMPLATE = "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
+JOURNAL_IMAGE_PATH_TEMPLATE = "assets/images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
 
 [[env.staging.kv_namespaces]]
 binding = "TS_IDEMPOTENCY"
@@ -153,7 +153,7 @@ JOURNAL_URL_TEMPLATE = "https://brockamer.github.io/trailscribe-journal/{yyyy}/{
 IMAGE_PROVIDER = "replicate"
 IMAGE_MODEL = "black-forest-labs/flux-schnell"
 IMAGE_COST_PER_CALL_USD = "0.003"
-JOURNAL_IMAGE_PATH_TEMPLATE = "_images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
+JOURNAL_IMAGE_PATH_TEMPLATE = "assets/images/{yyyy}-{mm}-{dd}-{slug}.{ext}"
 
 [[env.production.kv_namespaces]]
 binding = "TS_IDEMPOTENCY"


### PR DESCRIPTION
## Bug

\`!postimg\` posts render with a broken-image icon instead of the generated header image.

## Root cause

Jekyll treats any underscore-prefixed top-level directory as reserved (\`_posts\`, \`_layouts\`, \`_includes\`, etc.) and does **not** copy \`_images/\` into the rendered site. So the binary commit lands in the journal repo (correct), but \`<img src=\"/_images/...\">\` in the rendered HTML resolves to a 404 → broken-image icon.

The default \`JOURNAL_IMAGE_PATH_TEMPLATE = \"_images/{yyyy}-{mm}-{dd}-{slug}.{ext}\"\` was the offender — value carried over from the original P2-17 plan text without checking Jekyll's reserved-directory list.

## Fix

\`assets/images/{yyyy}-{mm}-{dd}-{slug}.{ext}\` — non-underscore so Jekyll treats it as an ordinary static-file directory.

Touched four files: \`wrangler.toml\` (3 stanzas), \`tests/helpers/env.ts\`, \`tests/p2-18-postimg.test.ts\` (atomic-commit assertion), \`CLAUDE.md\` (env-var reference).

## Stale posts

Two posts already committed under the old path during the staging burn-in (\`_posts/2026-04-29-sunset-above-lake-sabrina.md\` + replay-test sibling). Their markdown references the old \`/_images/...\` path and won't self-heal. Operator can either:

- **Delete** the two stale posts from the journal repo, OR
- **Manually move** \`_images/\` → \`assets/images/\` and edit the two markdown files in the journal repo to update the path.

Future \`!postimg\` events commit under the new path automatically.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] \`pnpm test\` — 314/314 (P2-18 atomic-commit assertion updated to expect new path)
- [ ] After merge + auto-deploy, send one \`!postimg\` from the Mini and verify the rendered post shows the image inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)