### PR TITLE
feat(grammar): !mail accepts t:/s:/b: short keys; subj/body optional (#123)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -45,7 +45,7 @@ TrailScribe is an AI-native serverless agent that transforms satellite messages 
 | Command | Purpose | External calls | Owner in decks |
 |---|---|---|---|
 | `!post <note>` | Journaling. Enriches position → narrative `{title, haiku, body}` → publishes to GitHub Pages journal. | LLM (OpenRouter), Nominatim (cached), Open-Meteo (cached), GitHub Pages (markdown commits) | Natalie, Marcus, Yuki |
-| `!mail to:_ subj:_ body:_` | Enriched email. Appends coordinates, place name, elevation, weather, map links. | Nominatim (cached), Open-Meteo (cached), Resend | Natalie, Marcus |
+| `!mail (to\|t):_ [(subj\|s):_] [(body\|b):_]` | Enriched email. Long keys (`to:`/`subj:`/`body:`) and short aliases (`t:`/`s:`/`b:`) interchangeable; `subj` and `body` independently optional. Appends coordinates, place name, elevation, weather, map links. | Nominatim (cached), Open-Meteo (cached), Resend | Natalie, Marcus |
 | `!todo <task>` | Creates a task in Todoist with GPS + timestamp in note. | Todoist | Natalie |
 | `!ping` | Health check → `pong`. | — | operational |
 | `!help` | Command summary. | — | operational |

--- a/docs/field-commands.md
+++ b/docs/field-commands.md
@@ -17,7 +17,7 @@ Keep the device's per-message **Include Location** toggle **off** for routine `!
 | `!cost` | `!cost` | Displays the number of requests, total tokens, and cumulative cost since the start of the current month. |
 | `!post` | `!post <note>` | Generates a journal post (title + haiku + body) via OpenRouter and commits it to the GitHub Pages journal repo. Reply links to the live URL. |
 | `!postimg` | `!postimg <caption>` | Same as `!post` plus an AI-generated header image. Image-gen via Replicate Flux schnell; markdown + image commit atomically to the journal repo. |
-| `!mail` | `!mail to:<address> subj:<subject> body:<body>` | Sends an email via Resend to `<address>` with the given subject and body. Location footer added automatically when GPS is available. |
+| `!mail` | `!mail (to\|t):<address> [(subj\|s):<subject>] [(body\|b):<body>]` | Sends an email via Resend to `<address>`. Long keys (`to:`/`subj:`/`body:`) and short aliases (`t:`/`s:`/`b:`) are interchangeable and may be mixed in one message. `subj` and `body` are optional — missing subject defaults to `[TrailScribe]`; missing body yields a footer-only email. Location footer added automatically when GPS is available. |
 | `!todo` | `!todo <task>` | Creates a Todoist task with `<task>` as the title. Reply includes the public Todoist URL. |
 | `!where` | `!where` | Reverse-geocodes the current GPS fix; reply names the place plus a Google Maps link (and a MapShare link if `MAPSHARE_BASE` is configured). |
 | `!weather` | `!weather` | Returns the current Open-Meteo conditions for the current GPS fix (e.g. `42°F, 8mph, clear`). |
@@ -31,7 +31,7 @@ Keep the device's per-message **Include Location** toggle **off** for routine `!
 ## Notes
 
 - **Case-insensitive.** `!Todo` and `!todo` behave the same; the leading exclamation mark is required.
-- **Argument order is fixed.** For `!mail`, the `to:`, `subj:`, and `body:` segments are mandatory and space-separated. For `!share`, `to:` is required.
+- **Argument order is fixed.** For `!mail`, only `to:` (or `t:`) is required; if present, `subj:`/`s:` must precede `body:`/`b:`. For `!share`, `to:` is required.
 - **Reply budget is sacred (≤320 chars total, two SMS).** Commands that produce longer content (`!post`, `!postimg`, `!brief`, `!ai`, `!camp`) page within the budget where the content fits and otherwise route to email or the journal post; a short device pointer ("see email" / "see journal") goes back to the Mini.
 - **Idempotency.** Garmin retries the same Outbound webhook on transient errors (2/4/8/16/32/64/128s, then 12h pauses for up to five days). The agent derives a per-event composite key (`sha256(imei + timeStamp + messageCode + content_hash)` per PRD §5) and short-circuits replays at both the app layer (`withCheckpoint`) and the per-command storage layers (FieldLog `id`, idempotency cache).
 - **Daily token budget.** LLM-bearing commands (`!post`, `!postimg`, `!brief`, `!ai`, `!camp`) honor `DAILY_TOKEN_BUDGET=50000`. When exceeded, the command short-circuits with a canned cap message rather than burning more spend.

--- a/src/core/commands/mail.ts
+++ b/src/core/commands/mail.ts
@@ -15,13 +15,18 @@ interface HandleMailContext extends OrchestratorContext {
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DEFAULT_SUBJECT = "[TrailScribe]";
 
 /**
- * `!mail to:_ subj:_ body:_` pipeline (plan P1-17).
+ * `!mail (to|t):_ [(subj|s):_] [(body|b):_]` pipeline (plan P1-17, extended #123).
  *
  * Composes optional geocode/weather → enriched email body → Resend send
  * (checkpointed) → ledger + context. Reply is `"Sent to <to>"` with map links
  * appended via buildReply when GPS is present.
+ *
+ * `subj` and `body` are independently optional in the grammar; missing `subj`
+ * falls back to `[TrailScribe]` (Resend rejects empty subjects), missing `body`
+ * yields a footer-only email.
  */
 export async function handleMail(cmd: MailCommand, ctx: HandleMailContext): Promise<CommandResult> {
   const { env, imei, lat, lon, idemKey } = ctx;
@@ -42,13 +47,14 @@ export async function handleMail(cmd: MailCommand, ctx: HandleMailContext): Prom
     if (wxR.status === "fulfilled") weather = wxR.value;
   }
 
-  const enrichedBody = composeBody(cmd.body, hasGps, placeName, weather, lat, lon);
+  const subject = cmd.subj && cmd.subj.length > 0 ? cmd.subj : DEFAULT_SUBJECT;
+  const enrichedBody = composeBody(cmd.body ?? "", hasGps, placeName, weather, lat, lon);
 
   try {
     await withCheckpoint(env, idemKey, "mail", async () => {
       const result = await sendEmail({
         to: cmd.to,
-        subject: cmd.subj,
+        subject,
         body: enrichedBody,
         env,
       });
@@ -87,7 +93,7 @@ export async function handleMail(cmd: MailCommand, ctx: HandleMailContext): Prom
         lat,
         lon,
         command_type: "mail",
-        free_text: `${cmd.to}|${cmd.subj}`,
+        free_text: `${cmd.to}|${subject}`,
       },
       env,
     );

--- a/src/core/grammar.ts
+++ b/src/core/grammar.ts
@@ -9,7 +9,7 @@ import type { ParsedCommand } from "./types.js";
  *   !help                                      command summary
  *   !cost                                      month-to-date usage
  *   !post <note>                               journal entry (LLM narrative)
- *   !mail to:<addr> subj:<subj> body:<body>    enriched email
+ *   !mail (to|t):<addr> [(subj|s):<subj>] [(body|b):<body>]   enriched email
  *   !todo <task>                               Todoist task
  *
  * Phase 2 commands (plans/phase-2-extended-commands.md P2-02 + P2-18):
@@ -47,12 +47,22 @@ export function parseCommand(message: string): ParsedCommand | undefined {
       return { type: "todo", task: rest };
     }
     case "mail": {
-      // Format: !mail to:<addr> subj:<subj with spaces OK> body:<body>
-      // The subj field must allow spaces — fixed from previous `[^\s]+` bug.
-      const match = rest.match(/^to:(\S+)\s+subj:(.+?)\s+body:(.+)$/i);
+      // Format: !mail (to|t):<addr> [(subj|s):<subj>] [(body|b):<body>]
+      // - `to:` / `t:` are interchangeable; same for `subj:` / `s:` and `body:` / `b:`.
+      // - Keys may be mixed within one message (e.g. `t:x@y.com subj:hi b:msg`).
+      // - Order is fixed (to → subj → body); subj and body are independently optional.
+      // - Default subject is supplied downstream by handleMail (see commands/mail.ts).
+      const match = rest.match(
+        /^(?:to|t):(\S+)(?:\s+(?:subj|s):(.+?))?(?:\s+(?:body|b):(.+))?$/i,
+      );
       if (!match) return undefined;
       const [, to, subj, body] = match;
-      return { type: "mail", to, subj: subj.trim(), body: body.trim() };
+      return {
+        type: "mail",
+        to,
+        ...(subj !== undefined ? { subj: subj.trim() } : {}),
+        ...(body !== undefined ? { body: body.trim() } : {}),
+      };
     }
     case "where":
       return { type: "where" };

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -87,7 +87,7 @@ function helpText(): string {
   return [
     "!ping — status",
     "!post <note> — blog",
-    "!mail to:_ subj:_ body:_",
+    "!mail t:_ [s:_] [b:_]",
     "!todo <task>",
     "!cost — usage",
     "!help",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,7 +11,7 @@ export type ParsedCommand =
   | { type: "help" }
   | { type: "cost" }
   | { type: "post"; note: string }
-  | { type: "mail"; to: string; subj: string; body: string }
+  | { type: "mail"; to: string; subj?: string; body?: string }
   | { type: "todo"; task: string }
   | { type: "where" }
   | { type: "weather" }

--- a/tests/grammar.test.ts
+++ b/tests/grammar.test.ts
@@ -48,6 +48,61 @@ describe("parseCommand — α-MVP commands", () => {
     });
   });
 
+  test("parses !mail with all short keys", () => {
+    expect(parseCommand("!mail t:x@y.com s:hello b:from the trail")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+      subj: "hello",
+      body: "from the trail",
+    });
+  });
+
+  test("parses !mail with mixed long + short keys", () => {
+    expect(parseCommand("!mail t:x@y.com subj:Hello b:msg")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+      subj: "Hello",
+      body: "msg",
+    });
+  });
+
+  test("parses !mail to-only (subj + body omitted)", () => {
+    expect(parseCommand("!mail to:x@y.com")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+    });
+    expect(parseCommand("!mail t:x@y.com")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+    });
+  });
+
+  test("parses !mail with subj only (body omitted)", () => {
+    expect(parseCommand("!mail to:x@y.com subj:hi there")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+      subj: "hi there",
+    });
+    expect(parseCommand("!mail t:x@y.com s:hi")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+      subj: "hi",
+    });
+  });
+
+  test("parses !mail with body only (subj omitted)", () => {
+    expect(parseCommand("!mail to:x@y.com body:from the trail")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+      body: "from the trail",
+    });
+    expect(parseCommand("!mail t:x@y.com b:msg")).toEqual({
+      type: "mail",
+      to: "x@y.com",
+      body: "msg",
+    });
+  });
+
   test("case-insensitive verb", () => {
     expect(parseCommand("!PING")).toEqual({ type: "ping" });
     expect(parseCommand("!Todo wash dishes")).toEqual({ type: "todo", task: "wash dishes" });
@@ -154,8 +209,10 @@ describe("parseCommand — rejects unknown / malformed input", () => {
   });
 
   test("returns undefined for malformed !mail", () => {
-    expect(parseCommand("!mail to:a@b.com subj:Hi")).toBeUndefined(); // missing body:
     expect(parseCommand("!mail just some text")).toBeUndefined();
+    expect(parseCommand("!mail subj:no-to-key body:msg")).toBeUndefined(); // missing to:/t:
+    expect(parseCommand("!mail to:")).toBeUndefined(); // empty to value
+    expect(parseCommand("!mail tt:x@y.com")).toBeUndefined(); // unknown key
   });
 
   test("returns undefined for Phase 2 commands missing required args", () => {

--- a/tests/p1-17-18-mail-todo-pipelines.test.ts
+++ b/tests/p1-17-18-mail-todo-pipelines.test.ts
@@ -170,6 +170,54 @@ describe("P1-17 !mail — no GPS", () => {
   });
 });
 
+describe("#123 !mail — short keys + optional subj/body", () => {
+  test("t:/s:/b: short keys send identically to to:/subj:/body:", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_short" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail t:friend@example.com s:hi b:hello"));
+
+    const resendCall = fetchSpy.mock.calls[0];
+    const resendBody = JSON.parse((resendCall[1] as RequestInit).body as string) as {
+      to: string;
+      subject: string;
+      text: string;
+    };
+    expect(resendBody.to).toBe("friend@example.com");
+    expect(resendBody.subject).toBe("hi");
+    expect(resendBody.text).toContain("hello");
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages.join(" ")).toContain("Sent to friend@example.com");
+  });
+
+  test("missing subj defaults subject to '[TrailScribe]'; missing body sends footer-only email", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("api.resend.com"),
+        respond: () => jsonResponse({ id: "re_msg_default" }),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!mail t:friend@example.com"));
+
+    const resendCall = fetchSpy.mock.calls[0];
+    const resendBody = JSON.parse((resendCall[1] as RequestInit).body as string) as {
+      subject: string;
+      text: string;
+    };
+    expect(resendBody.subject).toBe("[TrailScribe]");
+    expect(resendBody.text).toContain("From inReach — sent");
+    expect(resendBody.text.trim().startsWith("---")).toBe(true);
+  });
+});
+
 describe("P1-17 !mail — bad email address", () => {
   test("rejects syntactically invalid 'to' before any send", async () => {
     fetchSpy = vi.fn(async () => {


### PR DESCRIPTION
Closes #123.

## Summary

The Mini 3 Plus charges keystrokes against a 160-char outbound message budget; long `!mail` keys (`to:`/`subj:`/`body:`) eat into that budget enough to be friction in the field. Two bundled grammar changes:

- **Short-key aliases.** `t:` / `s:` / `b:` are accepted alongside `to:` / `subj:` / `body:`. Long and short forms are interchangeable and may be mixed in one message — e.g. `!mail t:x@y.com subj:hello b:from the trail` parses identically to the all-long or all-short variants.
- **Optional `subj` / `body`.** Only `to` (or `t`) is required. Missing subject defaults to `[TrailScribe]` (Resend rejects empty subjects); missing body yields a footer-only email with the location/weather block.

Order is still fixed (`to` → `subj` → `body`); reordering remains malformed.

## Files

| File | Change |
|---|---|
| `src/core/grammar.ts` | Single regex covering all valid `!mail` combinations |
| `src/core/types.ts` | `subj?: string`, `body?: string` on the `mail` variant |
| `src/core/commands/mail.ts` | `[TrailScribe]` default subject; thread resolved subject through context append |
| `src/core/orchestrator.ts` | `!help` text nudges short form: `!mail t:_ [s:_] [b:_]` |
| `docs/field-commands.md` | Documents both grammars + the optional-field semantics |
| `docs/PRD.md` §2 | Command table row updated to match |
| `tests/grammar.test.ts` | +7 cases (all-short, mixed, to-only, subj-only, body-only, malformed) |
| `tests/p1-17-18-mail-todo-pipelines.test.ts` | +2 integration cases (short-keys end-to-end, default-subject when subj omitted) |

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — **321/321** green (was 314; +7 new)

## Out of scope

- Same treatment for `!todo` / `!post` (positional, not keyed)
- A general short-key convention for future commands (file when those are designed)
- Out-of-order key support (would complicate the regex for an edge case nobody's hit)

## Milestone

Phase 2.5 — Field UX polish (due 2026-05-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)