### PR TITLE
feat(app): silent-drop non-!-prefixed device messages (closes #122, PRD §8 D10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ plans/                          # per-milestone sprint plans (active: phase-2-ex
 - **Strict TS**, JSDoc on exported functions, short focused functions.
 - **Reply budget:** total outgoing ≤320 chars including the cost suffix (when `APPEND_COST_SUFFIX=true`).
 - **Idempotency key:** `sha256(imei + ":" + timeStamp + ":" + messageCode + ":" + content_hash)` — Garmin has no `msgId` field, so we derive a composite key (see PRD §5).
+- **Intercept policy (PRD §8 D10):** non-`!`-prefixed device messages are silent-dropped at the webhook (200 OK, no IPC Inbound reply, structured `intercept_skipped` log). `!`-prefixed unknowns still get `"Try !help"`. Operator's casual messages to friends/family bypass TrailScribe entirely.
 - **Env:** validated via zod schema in `src/env.ts`; access via typed `Env` binding in Worker handlers.
 - **Tool adapters** live in `src/adapters/*` and accept `{ ...args, env: Env }`.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -388,6 +388,10 @@ If the same webhook replays after partial completion:
 - **D8. Outbound email:** **Resend.** `RESEND_API_KEY` secret; `RESEND_FROM_EMAIL=trailscribe@resend.dev` for α, move to own-domain later. Replaces all Gmail OAuth bindings in §3.
 - **D9. Email-fallback reply:** **permanently skipped** under the single-operator assumption. If IPC Inbound returns 5xx after 3 retries (1s/4s/16s backoff), write ledger entry `reply_delivery: failed` and return 200 OK to Garmin. Side effects (blog post, email, task) still persist. (Reconciled 2026-04-29 per `plans/phase-2-extended-commands.md` — was previously noted as "revisit in Phase 2.")
 
+### Resolved 2026-04-29
+
+- **D10. Intercept policy.** The Worker silent-drops messages whose `freeText` does not start with `!` (after trim) — no IPC Inbound reply, structured `intercept_skipped` log only, idempotency key recorded so Garmin retries short-circuit. `!`-prefixed messages with unknown verbs still receive `"Try !help"` so command typos remain recoverable. Decided 2026-04-29 (#122) after operator surfaced clutter from "Try !help" replies to casual messages during the #111 production turn-on. Recipient-gating (option 3 in #122 — only reply when device's `addresses[]` includes the TrailScribe contact) was deferred — revisit only if field experience surfaces a case where an `!`-prefixed message accidentally addressed to a non-TrailScribe contact produces unwanted replies.
+
 ### Original decision text (for reference)
 
 **D5. Blog platform (Posthaven cancelled).**

--- a/src/app.ts
+++ b/src/app.ts
@@ -138,7 +138,25 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
   const lat = hasFix ? point.latitude : undefined;
   const lon = hasFix ? point.longitude : undefined;
 
-  const command = parseCommand(event.freeText ?? "");
+  // Intercept policy (PRD §8 D10): silent-drop messages that don't begin with
+  // `!` so casual operator traffic to friends/family is invisible to TrailScribe.
+  // `!`-prefixed unknowns still receive "Try !help" so command typos remain
+  // recoverable. See #122.
+  const trimmed = (event.freeText ?? "").trim();
+  if (!trimmed.startsWith("!")) {
+    log({
+      event: "intercept_skipped",
+      level: "info",
+      imei: event.imei,
+      reason: "non-command",
+      freeTextPreview: trimmed.slice(0, 80),
+      key,
+    });
+    await markCompleted(env, key);
+    return;
+  }
+
+  const command = parseCommand(trimmed);
   if (!command) {
     log({
       event: "parse_unknown",

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -3,10 +3,13 @@ import { makeApp } from "../src/app.js";
 import { makeTestEnv, kvSize, kvKeys } from "./helpers/env.js";
 import type { Env } from "../src/env.js";
 import fixture from "./fixtures/garmin/free-text-ping.json";
+import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
 
 vi.mock("../src/adapters/outbound/garmin-ipc-inbound.js", () => ({
   sendReply: vi.fn().mockResolvedValue({ count: 1 }),
 }));
+
+const sendReplyMock = vi.mocked(sendReply);
 
 let app: ReturnType<typeof makeApp>;
 let env: Env;
@@ -14,6 +17,8 @@ let env: Env;
 beforeEach(() => {
   app = makeApp();
   env = makeTestEnv();
+  sendReplyMock.mockReset();
+  sendReplyMock.mockResolvedValue({ count: 1 });
 });
 
 async function postIpc(body: unknown, opts: { bearer?: string } = {}): Promise<Response> {
@@ -120,6 +125,57 @@ describe("Worker /garmin/ipc — Phase 0 behavior", () => {
     const keysEnv2 = kvKeys(env2.TS_IDEMPOTENCY);
 
     expect(keysEnv1).toEqual(keysEnv2);
+  });
+});
+
+describe("Worker /garmin/ipc — intercept policy (PRD §8 D10, #122)", () => {
+  function envelopeWithFreeText(freeText: string) {
+    return {
+      ...fixture,
+      Events: [{ ...fixture.Events[0], freeText, timeStamp: 1700000000000 }],
+    };
+  }
+
+  test("non-! text is silent-dropped: 200 OK, no IPC reply, idempotency key still recorded", async () => {
+    const res = await postIpc(envelopeWithFreeText("hi mom, made it to camp"), {
+      bearer: env.GARMIN_INBOUND_TOKEN,
+    });
+    expect(res.status).toBe(200);
+    expect(sendReplyMock).not.toHaveBeenCalled();
+    // Idempotency record exists so Garmin retries short-circuit.
+    expect(kvSize(env.TS_IDEMPOTENCY)).toBe(1);
+  });
+
+  test("empty freeText is silent-dropped: 200 OK, no IPC reply", async () => {
+    const res = await postIpc(envelopeWithFreeText(""), { bearer: env.GARMIN_INBOUND_TOKEN });
+    expect(res.status).toBe(200);
+    expect(sendReplyMock).not.toHaveBeenCalled();
+  });
+
+  test("whitespace-only freeText is silent-dropped: 200 OK, no IPC reply", async () => {
+    const res = await postIpc(envelopeWithFreeText("   \t  "), {
+      bearer: env.GARMIN_INBOUND_TOKEN,
+    });
+    expect(res.status).toBe(200);
+    expect(sendReplyMock).not.toHaveBeenCalled();
+  });
+
+  test("!-prefixed unknown verb still gets 'Try !help' (typo recoverability preserved)", async () => {
+    const res = await postIpc(envelopeWithFreeText("!pst hi"), {
+      bearer: env.GARMIN_INBOUND_TOKEN,
+    });
+    expect(res.status).toBe(200);
+    expect(sendReplyMock).toHaveBeenCalledTimes(1);
+    const [, messages] = sendReplyMock.mock.calls[0];
+    expect(messages.join(" ")).toContain("Try !help");
+  });
+
+  test("leading whitespace before ! is tolerated (treated as command, not silent-dropped)", async () => {
+    const res = await postIpc(envelopeWithFreeText("  !ping"), {
+      bearer: env.GARMIN_INBOUND_TOKEN,
+    });
+    expect(res.status).toBe(200);
+    expect(sendReplyMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/p1-19-commands.test.ts
+++ b/tests/p1-19-commands.test.ts
@@ -197,13 +197,22 @@ describe("P1-19 — APPEND_COST_SUFFIX integration", () => {
 });
 
 describe("P1-19 — unknown command path", () => {
-  test("unparseable text → 'Unknown command. Try !help' delivered, no ledger entry", async () => {
-    const res = await postIpc(envelope("not a command"));
+  test("!-prefixed unknown verb → 'Unknown command. Try !help' delivered, no ledger entry", async () => {
+    const res = await postIpc(envelope("!nope hi"));
     expect(res.status).toBe(200);
 
     const [, messages] = sendReplyMock.mock.calls[0];
     expect(messages).toEqual(["Unknown command. Try !help"]);
 
+    const snap = await monthlyTotals(env);
+    expect(snap.requests).toBe(0);
+  });
+
+  test("non-!-prefixed text is silent-dropped under D10 intercept policy (#122)", async () => {
+    const res = await postIpc(envelope("not a command"));
+    expect(res.status).toBe(200);
+
+    expect(sendReplyMock).not.toHaveBeenCalled();
     const snap = await monthlyTotals(env);
     expect(snap.requests).toBe(0);
   });


### PR DESCRIPTION
Closes #122.

## Summary

Garmin Pro tenant relays **every** device-outbound message to the webhook, not just `!commands`. The previous behavior replied `"Unknown command. Try !help"` to anything that didn't parse — which meant TrailScribe replied to the operator's casual messages to friends/family, cluttering the device and burning IPC quota on unintended traffic. The operator surfaced this during the #111 production turn-on.

## New intercept policy (PRD §8 D10 — `option 4` from #122)

- **`freeText` that doesn't start with `!` (after trim) → silent-drop.** 200 OK, no IPC Inbound reply, structured `intercept_skipped` log. Idempotency key still recorded so Garmin retries short-circuit.
- **`!`-prefixed but unknown verb → `"Unknown command. Try !help"`** (preserved so command typos remain recoverable).

Recipient-gating (option 3 in #122 — only reply when device's `addresses[]` includes the TrailScribe contact) was deferred. It would have required a new env var to identify the device-side TrailScribe contact (today `IPC_INBOUND_SENDER` and the device contact `trailscribe@tx.trailscribe.net` are different values) and a verification that Garmin actually populates `addresses[]` on outbound device→tenant traffic. Option 4 sidesteps both. Revisit only if field experience surfaces a case where an `!`-prefixed message accidentally addressed to a non-TrailScribe contact produces unwanted replies.

## Files

| File | Change |
|---|---|
| `src/app.ts` | Trim `freeText` once; gate on `!`-prefix before `parseCommand`; structured `intercept_skipped` log on silent-drop path |
| `tests/app.test.ts` | +5 cases: non-`!` silent-drop, empty/whitespace silent-drop, `!`-unknown still replies, leading-whitespace tolerated |
| `tests/p1-19-commands.test.ts` | Retarget the existing "unparseable text" case to a `!`-prefixed unknown (the original `"not a command"` string is now silent-dropped under D10); add a new case explicitly verifying the silent-drop |
| `docs/PRD.md` §8 | D10 added under "Resolved 2026-04-29" with rationale + deferred-option-3 note |
| `CLAUDE.md` Conventions | One-line policy summary |

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — **327/327** green (was 321 + 6 new + 1 retargeted)

## Operational note

The first time this lands in production, the structured-log `intercept_skipped` events will be visible in `wrangler tail` whenever the operator sends a non-`!command` message. Useful for verifying the policy is working as intended; harmless if it isn't.

## Milestone

Phase 2.5 — Field UX polish (due 2026-05-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)