### PR TITLE
feat(grammar): allow bare !post — narrative from device metadata (#124)

### DIFF
--- a/docs/field-commands.md
+++ b/docs/field-commands.md
@@ -15,7 +15,7 @@ Keep the device's per-message **Include Location** toggle **off** for routine `!
 | `!ping` | `!ping` | Health check. Replies `pong` to confirm the agent is running. |
 | `!help` | `!help` | Shows the command summary on-device. |
 | `!cost` | `!cost` | Displays the number of requests, total tokens, and cumulative cost since the start of the current month. |
-| `!post` | `!post <note>` | Generates a journal post (title + haiku + body) via OpenRouter and commits it to the GitHub Pages journal repo. Reply links to the live URL. |
+| `!post` | `!post [note]` | Generates a journal post (title + haiku + body) via OpenRouter and commits it to the GitHub Pages journal repo. Reply links to the live URL. **Bare `!post`** (no caption) builds the narrative purely from device metadata — place name, weather, time — in observational voice, without inventing activities or feelings. |
 | `!postimg` | `!postimg <caption>` | Same as `!post` plus an AI-generated header image. Image-gen via Replicate Flux schnell; markdown + image commit atomically to the journal repo. |
 | `!mail` | `!mail (to\|t):<address> [(subj\|s):<subject>] [(body\|b):<body>]` | Sends an email via Resend to `<address>`. Long keys (`to:`/`subj:`/`body:`) and short aliases (`t:`/`s:`/`b:`) are interchangeable and may be mixed in one message. `subj` and `body` are optional — missing subject defaults to `[TrailScribe]`; missing body yields a footer-only email. Location footer added automatically when GPS is available. |
 | `!todo` | `!todo <task>` | Creates a Todoist task with `<task>` as the title. Reply includes the public Todoist URL. |

--- a/src/core/commands/post.ts
+++ b/src/core/commands/post.ts
@@ -99,6 +99,22 @@ export async function handlePost(cmd: PostCommand, ctx: HandlePostContext): Prom
     return failPipeline(env, idemKey, "narrative", err);
   }
 
+  // Bare-!post fallback (#124): if the LLM produced nothing usable from the
+  // metadata-only prompt (e.g. no GPS fix and no place/weather to ground it),
+  // synthesize a minimal narrative so the pipeline still produces a journal
+  // post. Schema validation already rejects empty title/haiku/body, so this
+  // branch is defensive — it triggers only on the title-only edge case where
+  // the model returned bare metadata echo.
+  if (cmd.note === undefined && narrative.title.trim().length === 0) {
+    const fallbackTitle = placeName ? `Posted from ${placeName}` : "Posted from the field";
+    narrative = {
+      ...narrative,
+      title: fallbackTitle,
+      haiku: narrative.haiku || fallbackTitle,
+      body: narrative.body || fallbackTitle,
+    };
+  }
+
   let publishResult: Awaited<ReturnType<typeof publishPost>>;
   try {
     publishResult = await withCheckpoint(env, idemKey, "publish", () =>
@@ -142,7 +158,7 @@ export async function handlePost(cmd: PostCommand, ctx: HandlePostContext): Prom
         lat,
         lon,
         command_type: "post",
-        free_text: cmd.note,
+        free_text: cmd.note ?? "",
       },
       env,
     );

--- a/src/core/grammar.ts
+++ b/src/core/grammar.ts
@@ -39,8 +39,7 @@ export function parseCommand(message: string): ParsedCommand | undefined {
     case "cost":
       return { type: "cost" };
     case "post": {
-      if (!rest) return undefined;
-      return { type: "post", note: rest };
+      return rest ? { type: "post", note: rest } : { type: "post" };
     }
     case "todo": {
       if (!rest) return undefined;

--- a/src/core/narrative.ts
+++ b/src/core/narrative.ts
@@ -18,8 +18,13 @@ import { log } from "../adapters/logging/worker-logs.js";
  * character-count proxies (drift over time, undercounts on multi-byte text).
  */
 export interface NarrativeInput {
-  /** The user's note text from `!post <note>`. */
-  note: string;
+  /**
+   * The user's note text from `!post <note>`. Omitted for bare `!post` (#124),
+   * in which case the LLM constructs the narrative purely from enrichment
+   * context (lat/lon/placeName/weather) and is given a no-note system prompt
+   * that explicitly forbids inventing activities or feelings.
+   */
+  note?: string;
   lat?: number;
   lon?: number;
   /** Reverse-geocoded place name (P1-09). Optional — omitted prompt when absent. */
@@ -66,13 +71,30 @@ const NarrativeContentSchema = z.object({
  * length caps server-side; the prompt is what makes the model actually *try*
  * to stay within them and to match the user's voice.
  */
-const SYSTEM_PROMPT = [
+const SYSTEM_PROMPT_WITH_NOTE = [
   "You write short field-journal entries from a backcountry traveller's brief notes.",
   "Always return valid JSON matching the schema. No prose outside the JSON.",
   "Constraints:",
   '- "title": ≤ 60 characters, evocative, no clickbait, no emoji.',
   '- "haiku": exactly three lines separated by newlines, in 5/7/5 syllables, ≤ 110 characters total (count strictly — including spaces and newlines). Plain English. No formatting marks.',
   '- "body": ≤ 500 characters. Match the voice and tone of the input note. First-person if the note is first-person; observational if observational. Do not invent specifics not implied by the note, place, or weather context.',
+].join("\n");
+
+/**
+ * No-note variant for bare `!post` (#124). The operator sent no caption, so the
+ * LLM must construct the narrative purely from enrichment context (location,
+ * weather, time). Tone is observational rather than first-person, and the
+ * model is explicitly forbidden from inventing activities, feelings, or
+ * specifics not present in the metadata — a stronger constraint than the
+ * with-note prompt because there's no anchoring caption to ground it.
+ */
+const SYSTEM_PROMPT_NO_NOTE = [
+  "You write short field-journal entries from a backcountry traveller's location and weather snapshot. The traveller did not provide a caption — describe what is true about this position and moment, in observational third-person, from the metadata alone.",
+  "Always return valid JSON matching the schema. No prose outside the JSON.",
+  "Constraints:",
+  '- "title": ≤ 60 characters, evocative, no clickbait, no emoji. Anchor to the place name or weather, not to invented activities.',
+  '- "haiku": exactly three lines separated by newlines, in 5/7/5 syllables, ≤ 110 characters total (count strictly — including spaces and newlines). Plain English. No formatting marks. Anchor to observable detail (place, weather, time, terrain).',
+  '- "body": ≤ 500 characters. Observational voice. Do not invent activities, feelings, companions, or specifics that are not present in the location or weather context. If context is sparse, keep the body short rather than padding.',
 ].join("\n");
 
 export class NarrativeError extends Error {
@@ -85,12 +107,16 @@ export class NarrativeError extends Error {
 export async function generateNarrative(input: NarrativeInput): Promise<NarrativeOutput> {
   const userPrompt = buildUserPrompt(input);
   const model = input.env.LLM_MODEL || "anthropic/claude-sonnet-4-6";
+  const systemPrompt =
+    input.note !== undefined && input.note.trim().length > 0
+      ? SYSTEM_PROMPT_WITH_NOTE
+      : SYSTEM_PROMPT_NO_NOTE;
 
   const response = await chatCompletion({
     req: {
       model,
       messages: [
-        { role: "system", content: SYSTEM_PROMPT },
+        { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
       response_format: { type: "json_schema", json_schema: NARRATIVE_SCHEMA },
@@ -151,10 +177,16 @@ export async function generateNarrative(input: NarrativeInput): Promise<Narrativ
  * (no GPS fix or geocode/weather lookup failed upstream), those lines are
  * omitted entirely — no "(unknown)" or "(0,0)" placeholders that would steer
  * the model toward synthesising location-specific detail.
+ *
+ * Bare `!post` (#124) supplies no `note` — the `Note:` line is omitted and the
+ * model relies on the no-note system prompt + enrichment lines below.
  */
 function buildUserPrompt(input: NarrativeInput): string {
   const lines: string[] = [];
-  lines.push(`Note: ${input.note}`);
+
+  if (input.note !== undefined && input.note.trim().length > 0) {
+    lines.push(`Note: ${input.note}`);
+  }
 
   if (
     input.placeName !== undefined &&

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -86,7 +86,7 @@ export async function orchestrate(
 function helpText(): string {
   return [
     "!ping — status",
-    "!post <note> — blog",
+    "!post [note] — blog",
     "!mail t:_ [s:_] [b:_]",
     "!todo <task>",
     "!cost — usage",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,7 +10,7 @@ export type ParsedCommand =
   | { type: "ping" }
   | { type: "help" }
   | { type: "cost" }
-  | { type: "post"; note: string }
+  | { type: "post"; note?: string }
   | { type: "mail"; to: string; subj?: string; body?: string }
   | { type: "todo"; task: string }
   | { type: "where" }

--- a/tests/grammar.test.ts
+++ b/tests/grammar.test.ts
@@ -200,8 +200,9 @@ describe("parseCommand — rejects unknown / malformed input", () => {
     expect(parseCommand("!foo bar")).toBeUndefined();
   });
 
-  test("returns undefined for !post without a note", () => {
-    expect(parseCommand("!post")).toBeUndefined();
+  test("parses bare !post (#124) — narrative built from metadata", () => {
+    expect(parseCommand("!post")).toEqual({ type: "post" });
+    expect(parseCommand("!post  ")).toEqual({ type: "post" });
   });
 
   test("returns undefined for !todo without a task", () => {

--- a/tests/narrative.test.ts
+++ b/tests/narrative.test.ts
@@ -155,6 +155,69 @@ describe("generateNarrative — prompt composition", () => {
     expect(userMsg).not.toContain("(unknown)");
   });
 
+  test("bare !post (no note, #124) → user prompt OMITS 'Note:' line; system prompt forbids invention", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({
+      lat: 37.1682,
+      lon: -118.5891,
+      placeName: "Lake Sabrina, Inyo County, CA",
+      weather: "Clear · 8°C · wind 12 km/h W",
+      env,
+    });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = body.messages.find((m) => m.role === "user")?.content ?? "";
+    const sysMsg = body.messages.find((m) => m.role === "system")?.content ?? "";
+
+    expect(userMsg).not.toContain("Note:");
+    expect(userMsg).toContain("Location: Lake Sabrina");
+    expect(userMsg).toContain("Weather: Clear");
+
+    expect(sysMsg).toContain("did not provide a caption");
+    expect(sysMsg.toLowerCase()).toContain("do not invent");
+  });
+
+  test("whitespace-only note → treated as bare (no-note prompt path)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "   ", placeName: "X", lat: 1, lon: 2, env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const sysMsg = body.messages.find((m) => m.role === "system")?.content ?? "";
+    const userMsg = body.messages.find((m) => m.role === "user")?.content ?? "";
+
+    expect(sysMsg).toContain("did not provide a caption");
+    expect(userMsg).not.toContain("Note:");
+  });
+
+  test("with-note path → system prompt is the original first-person variant", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateNarrative({ note: "feeling great", env });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const sysMsg = body.messages.find((m) => m.role === "system")?.content ?? "";
+
+    expect(sysMsg).not.toContain("did not provide a caption");
+    expect(sysMsg).toContain("brief notes");
+  });
+
   test("placeName missing but lat/lon present → still omits Location (need all three)", async () => {
     fetchSpy.mockResolvedValueOnce(
       jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),

--- a/tests/p1-16-post-pipeline.test.ts
+++ b/tests/p1-16-post-pipeline.test.ts
@@ -248,6 +248,107 @@ describe("P1-16 !post — no GPS fix", () => {
   });
 });
 
+describe("#124 bare !post — narrative built from metadata, no caption", () => {
+  test("bare !post with GPS → geocode + weather called; no-note prompt; journal post produced", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("nominatim.openstreetmap.org"),
+        respond: () => jsonResponse({ display_name: "Lake Sabrina, Inyo County, California" }),
+      },
+      {
+        match: (u) => u.includes("api.open-meteo.com"),
+        respond: () =>
+          jsonResponse({
+            current: { temperature_2m: 46, wind_speed_10m: 8, weather_code: 0 },
+          }),
+      },
+      {
+        match: (u) => u.includes("openrouter.ai"),
+        respond: () => jsonResponse(NARRATIVE_RESPONSE),
+      },
+      {
+        match: (u, i) => u.includes("api.github.com") && i?.method === "GET",
+        respond: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u, i) => u.includes("api.github.com") && i?.method === "PUT",
+        respond: () => jsonResponse(PUBLISH_RESPONSE),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const res = await postIpc(envelope("!post", { gps: { lat: NATALIE_LAT, lon: NATALIE_LON } }));
+    expect(res.status).toBe(200);
+
+    // Bare !post should still produce a journal post (the operator's intent
+    // was "TrailScribe figures it out" — a parse error wastes a satellite send).
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("Posted: Alpenglow at Lake Sabrina");
+    expect(joined).toContain("https://brockamer.github.io/trailscribe-journal/");
+
+    // Narrative prompt: no-note variant + omitted "Note:" line.
+    const orCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("openrouter.ai"),
+    );
+    const orBody = JSON.parse((orCall![1] as RequestInit).body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const sysMsg = orBody.messages.find((m) => m.role === "system")?.content ?? "";
+    const userMsg = orBody.messages.find((m) => m.role === "user")?.content ?? "";
+    expect(sysMsg).toContain("did not provide a caption");
+    expect(userMsg).not.toContain("Note:");
+    expect(userMsg).toMatch(/^Location: /m);
+    expect(userMsg).toMatch(/^Weather: /m);
+  });
+
+  test("bare !post with no GPS fix → no-note prompt; minimal user prompt; journal post still produced", async () => {
+    fetchSpy = makeFetchRouter([
+      {
+        match: (u) => u.includes("openrouter.ai"),
+        respond: () => jsonResponse(NARRATIVE_RESPONSE),
+      },
+      {
+        match: (u, i) => u.includes("api.github.com") && i?.method === "GET",
+        respond: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u, i) => u.includes("api.github.com") && i?.method === "PUT",
+        respond: () => jsonResponse(PUBLISH_RESPONSE),
+      },
+    ]);
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await postIpc(envelope("!post"));
+
+    // No geocode / weather without GPS, even on bare path.
+    const calls = fetchSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(calls.some((u: string) => u.includes("nominatim"))).toBe(false);
+    expect(calls.some((u: string) => u.includes("open-meteo"))).toBe(false);
+
+    // Reply should still carry the journal URL — bare + no-GPS is a real edge
+    // case (operator triggers !post indoors / before fix locks) and must
+    // degrade gracefully, not error.
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const joined = messages.join(" ");
+    expect(joined).toContain("Posted: Alpenglow at Lake Sabrina");
+
+    const orCall = fetchSpy.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("openrouter.ai"),
+    );
+    const orBody = JSON.parse((orCall![1] as RequestInit).body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = orBody.messages.find((m) => m.role === "user")?.content ?? "";
+    // No Note, no Location, no Weather — degenerate but valid input. The
+    // no-note system prompt tells the LLM to keep the body short rather than
+    // pad in this case.
+    expect(userMsg).not.toContain("Note:");
+    expect(userMsg).not.toContain("Location:");
+    expect(userMsg).not.toContain("Weather:");
+  });
+});
+
 describe("P1-16 !post — replay safety (acceptance #5)", () => {
   test("first run completes narrative + publish; reply send fails; replay re-runs reply only", async () => {
     let openRouterCalls = 0;


### PR DESCRIPTION
## Summary

- Bare `!post` (no caption) now parses and produces a journal post — previously returned `undefined` and replied "Unknown command. Try !help", wasting a satellite send.
- The LLM builds the narrative purely from enrichment context (place name, weather, time) under a **no-note system prompt** that explicitly forbids inventing activities, feelings, or specifics not present in metadata. Observational third-person voice instead of first-person.
- `note` is now `string | undefined` on the `post` ParsedCommand variant. Whitespace-only notes are treated as bare (cleaner than the empty-string ambiguity).
- Closes Phase 2.5's last open issue — milestone goes 0/3 once this lands.

Surfaced 2026-04-27 during #111 production traffic turn-on (operator typed bare `!post` expecting "TrailScribe figures it out").

## Acceptance criteria (from issue body)

- [x] `src/core/grammar.ts` — bare `!post` parses as `{ type: "post" }` (note omitted at the type level — distinguishes "bare" from "empty after trim")
- [x] `src/core/types.ts` — `note?: string` on the `post` variant
- [x] `src/core/commands/post.ts` — branches on `cmd.note === undefined`; defensive empty-narrative fallback (`Posted from {placeName}` or `Posted from the field`)
- [x] `src/core/narrative.ts` — `SYSTEM_PROMPT` split into `WITH_NOTE` / `NO_NOTE`; `buildUserPrompt` omits the `Note:` line when absent
- [x] Vitest cases — 1 grammar test (replaces the negative case), 3 narrative-prompt tests, 2 end-to-end pipeline tests (`!post` with GPS, bare + no-GPS edge case)
- [x] `docs/field-commands.md` documents the bare mode
- [x] `!help` reply text updates: `!post [note] — blog`

**Tests:** 332/332 (was 327; +5 new). Typecheck + lint clean.

## Cost envelope (open question from issue body)

The risk note flagged whether bare-mode input tokens stay under PRD §6's <\$0.05/transaction. Plan: probe staging with one bare `!post` + one with-note `!post`, compare ledger deltas. Will post the numbers as a PR comment before requesting merge.

## Test plan

- [ ] Deploy to staging via `pnpm deploy:staging` (pre-approved, dry-run first)
- [ ] Probe bare `!post` against staging Worker; capture token usage from ledger
- [ ] Probe with-note `!post` against staging; compare deltas
- [ ] Confirm bare path stays under <\$0.05/transaction; if not, investigate prompt-trimming before merge
- [ ] Real-device verification deferred until P2-16 (operator + Mini in field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)