### PR TITLE
docs(readme): rewrite for plain-language overview + contributor invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ files the task), and writes back to your device in two SMS or fewer.
 
 You get the leverage of a full software stack — AI, email, journaling, task
 management — through a 160-character window, anywhere on Earth that has a
-clear view of the sky.
+clear view of the sky. **No phone, no cell signal, no Wi-Fi required.**
+
+> ⚠️ **Requires a Garmin inReach Professional plan.** TrailScribe is built on
+> Garmin's IPC Outbound + Inbound APIs, which are only exposed on the
+> [Professional subscription tier](https://www.garmin.com/en-US/p/837481/pn/010-D2242-SU/)
+> — not consumer inReach plans. Plans start around $20/month.
+
+> 🛰️ **Live progress + open issues:** [project board](https://github.com/users/brockamer/projects/3)
+> · roadmap arc in [`docs/PRD.md`](docs/PRD.md) §9
 
 ---
 
@@ -59,6 +67,39 @@ lives in [`docs/field-commands.md`](docs/field-commands.md).
 | **Marcus** — expedition guide, PNW / Alaska / Patagonia | 8–12 day trips, 6–10 clients | Evening `!post` publishes to a private expedition blog families follow in real time; `!blast` keeps the trip-watch list synchronized. |
 | **Yuki** — solo bikepacker and storyteller, Iceland / Mongolia | 3–6 week trips | The blog never goes dark; real-time narrative without café data-entry days. `!postimg` gives the journal a visual identity from the field. |
 
+## What you might use it for
+
+The personas above are the ones we designed against, but the architecture is
+deliberately general — anything you can do in 160 characters, from a place
+with sky, can become a command. A few directions worth imagining:
+
+- **Long-distance hiker.** Your trail journal updates from the trail itself.
+  Your family knows you're alive *and* what you saw today, not just a dot on
+  a map. A `!todo "resupply box, Echo Lake"` from mile 1,400 lands in your
+  task manager before you forget.
+- **Sailing or expedition crew on a passage.** Daily noon-position email to
+  the shore team is one `!blast`. Weather query before a tack is one
+  `!weather`. The whole trip log builds itself in a journal you don't open
+  until landfall.
+- **Disaster-response volunteer when local cell is out.** File structured
+  incident reports — location, observation, severity, time — to a coordinator
+  who's still online. Not a replacement for radio nets; a complement to them.
+- **Rural rancher or property caretaker.** From the far corner of a 5,000-acre
+  spread: log a fence break, a water-tank reading, a coyote sighting. The
+  ranch task list updates without the drive back to the house.
+- **Wildlife biologist or conservation surveyor.** Geotag sightings into a
+  shared dataset as you walk a transect. Collaborators see the data appear in
+  real time. Specimen photos go up via `!postimg`.
+- **Field journalist in a remote area.** File dispatches by satellite — pull
+  quotes by email to an editor, full piece to a public journal site, all
+  without ever touching a laptop until you're back on a power grid.
+
+The general shape: anywhere a short piece of structured text from the field
+needs to fan out into the connected world, TrailScribe is a 160-character
+adapter. The command set is open-ended — if a verb you want isn't there, it's
+a parser change and a tool adapter, not a redesign. Open an issue with the
+use case and we'll talk about it.
+
 ## What it costs
 
 Design target: **under $0.05 per transaction, ~$0.03 typical**. Cheaper than
@@ -70,13 +111,6 @@ A daily token budget caps spend at a configurable ceiling (default
 ≈150 narratives/day) and short-circuits AI calls when exceeded so a runaway
 prompt can't drain the wallet. Per-transaction cost detail is in
 [`docs/PRD.md`](docs/PRD.md) §6.
-
-## Status
-
-α-MVP and the Phase 2 extended command set are shipped end-to-end on
-production. Live progress is on the
-[project board](https://github.com/users/brockamer/projects/3); current-state
-specifics live in [`CLAUDE.md`](CLAUDE.md) and the PRD.
 
 ## Why this works
 
@@ -97,13 +131,66 @@ The tradeoffs:
   where the device gets paginated walls of text.
 - **Not a safety system.** SOS goes through Garmin's native button to
   IERCC/GEOS, not TrailScribe.
-- **Single-operator by design.** This is a personal project — one IMEI in
-  the allowlist, one operator, no β-launch. The architecture is sized
-  accordingly.
+- **Single-operator by design — for now.** Today the architecture is sized
+  for one IMEI in the allowlist. Multi-tenant is a question for later phases
+  (see the engineering details below); the patterns are already in place to
+  grow into it.
 
 ---
 
-## Under the hood
+## Help build it
+
+TrailScribe is a personal project built mostly by one operator — a 20-year
+sysadmin learning modern serverless patterns — in close collaboration with
+Claude Code. It works end-to-end on production today, but it's at the stage
+where having other humans in the codebase would change the shape of the
+project for the better: different angles on the architecture, code-review
+habits that don't form when you're alone, design conversations that go
+places a single contributor and an AI can't reach.
+
+**If any of these sound like you, say hi:**
+
+- You've built on Cloudflare Workers / Durable Objects / D1 in production and
+  want to see how a small project applies them.
+- You've worked with LLMs under tight character budgets and want to push the
+  prompt engineering further.
+- You own an inReach (or any Iridium-tier satellite communicator) and want a
+  real-world test environment.
+- You like teaching — code review on a small repo where the maintainer is
+  *explicitly* trying to learn from collaborators.
+- You have a use case the personas don't cover and you want it to work.
+
+Where to start:
+
+1. Skim the [project board](https://github.com/users/brockamer/projects/3)
+   — issues marked **Up Next** or **help wanted** are the best entry points.
+2. For larger pieces of work, open an issue first so we can shape it
+   together. The bigger the change, the earlier the conversation.
+3. Conventions, branch model, and the PR-per-change discipline are in
+   [`CONTRIBUTING.md`](CONTRIBUTING.md). Every change in this repo lands as
+   its own squash-merged PR; the commit log doubles as project history.
+4. Code of conduct lives in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md);
+   security policy in [`SECURITY.md`](SECURITY.md).
+
+---
+
+<details>
+<summary><b>Engineering details</b> — architecture, status, stack, quick start, roadmap</summary>
+
+### Status
+
+- **Phase 0** (Workers scaffold) — shipped 2026-04-24
+- **Phase 1** (α-MVP, six commands) — shipped 2026-04-27
+- **Production-readiness** (auto-deploy, device-side conventions) — shipped 2026-04-28
+- **Phase 2** (extended command set + `!postimg`) — shipped 2026-04-29
+- **Phase 2.5** (UX polish: intercept policy, `!mail` short keys, bare `!post`) — in flight, milestone #6
+- **Phase 3** (storage migration: KV → Durable Objects + D1) — next infra phase, epic [#99](https://github.com/brockamer/trailscribe/issues/99)
+- **Phase 4** (`!snap`, `!call`) — telemetry-only journal posts and a PSTN voice-bridge command, milestone #7
+
+Live state and open issues: [project board](https://github.com/users/brockamer/projects/3).
+Long-form roadmap rationale in [`docs/PRD.md`](docs/PRD.md) §9.
+
+### Under the hood
 
 ```
   inReach                           Cloudflare Worker (Hono)
@@ -131,10 +218,11 @@ replays at both the orchestrator and per-command storage layers.
 State lives in four Cloudflare KV namespaces — `TS_IDEMPOTENCY` (48h TTL),
 `TS_LEDGER` (monthly rollup), `TS_CONTEXT` (per-IMEI rolling window),
 `TS_CACHE` (geocode + weather). KV is Cloudflare's globally-replicated
-key-value store; Durable Objects (single-machine state with strong
-consistency) and D1 (serverless SQLite) are filed for a future Phase 3
-migration when KV's eventual consistency or list-scan ledger queries
-actually start to bite. Full architecture in
+key-value store; **Durable Objects** (single-instance stateful Workers that
+serialize writes per object — like a tiny single-threaded server with
+attached storage, one per IMEI) and **D1** (Cloudflare's serverless SQLite)
+are filed for the Phase 3 migration when KV's eventual consistency or
+list-scan ledger queries actually start to bite. Full architecture in
 [`docs/architecture.md`](docs/architecture.md) and
 [`docs/PRD.md`](docs/PRD.md) §3.
 
@@ -146,7 +234,7 @@ actually start to bite. Full architecture in
 | Language | TypeScript (strict, ESM) |
 | HTTP | Hono |
 | Validation | zod |
-| State | Cloudflare KV — four namespaces |
+| State | Cloudflare KV — four namespaces (DO + D1 in Phase 3) |
 | LLM | OpenRouter → `anthropic/claude-sonnet-4-6` |
 | Image-gen | Replicate Flux schnell (`!postimg` only) |
 | Email | Resend |
@@ -161,9 +249,10 @@ actually start to bite. Full architecture in
 ### Quick start
 
 Prerequisites: Node ≥ 20, pnpm 9+ (via corepack), a Cloudflare account, and
-a Garmin **inReach Professional** plan — the IPC Outbound + Inbound APIs
-this depends on are not exposed on consumer plans. See
-[`docs/PRD.md`](docs/PRD.md) §8 for the tier-requirement rationale.
+a [Garmin **inReach Professional** plan](https://www.garmin.com/en-US/p/837481/pn/010-D2242-SU/)
+— the IPC Outbound + Inbound APIs this depends on are not exposed on
+consumer plans. See [`docs/PRD.md`](docs/PRD.md) §8 for the tier-requirement
+rationale.
 
 ```bash
 pnpm install
@@ -193,6 +282,8 @@ Pushes to `staging/**` branches auto-deploy to staging, and pushes to `main`
 auto-deploy to production, via
 [`.github/workflows/deploy-cloudflare.yml`](.github/workflows/deploy-cloudflare.yml).
 A manual `workflow_dispatch` is also available for either target.
+
+</details>
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Restructures README to lead with **what TrailScribe lets you do from a satellite messenger** (no phone, no internet) for casual readers — opening, command table, personas, and "what you might use it for" all stay above the fold.
- Adds a **speculative use-cases section** (long-distance hiker, sailing crew, disaster-response volunteer, rural rancher, wildlife biologist, field journalist) to help readers project their own scenarios beyond the canonical personas.
- Adds a **contributor invitation** that names the project's actual goal: a 20-year sysadmin learning modern serverless patterns wants other humans (not just Claude) collaborating.
- Tucks all **engineering content** (status, architecture diagram, stack table, quick start, Phase 3+ roadmap) inside a collapsed `<details>` toggle so casual readers don't have to scroll past it.
- Adds a **visible callout** that an [inReach Professional plan](https://www.garmin.com/en-US/p/837481/pn/010-D2242-SU/) is required (plans start ~\$20/mo).
- Promotes the [project board](https://github.com/users/brockamer/projects/3) link to a prominent quote-block near the top, plus mentions in the contributor section and engineering toggle.

## Test plan

- [x] README renders correctly on GitHub (`<details>` toggle expand/collapse works natively)
- [x] All internal doc links still resolve (PRD, architecture, field-commands, setup, project-board, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT)
- [x] External Garmin product link resolves to Professional subscription plans page
- [x] No code/worker changes — docs-only, auto-deploy is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)