### PR TITLE
chore(diag): LOG_TRACK_PAYLOADS env to capture tracking event bodies

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "./env.js";
-import { appendCostSuffix, imeiAllowSet, ipcInboundDryRun } from "./env.js";
+import { appendCostSuffix, imeiAllowSet, ipcInboundDryRun, logTrackPayloads } from "./env.js";
 import type { CommandResult, GarminEnvelope, GarminEvent } from "./core/types.js";
 import {
   idempotencyKey,
@@ -119,12 +119,21 @@ async function handleEvent(event: GarminEvent, env: Env, allow: Set<string>): Pr
     if (event.messageCode === 4) {
       log({ event: "sos_received_ignored", level: "warn", imei: event.imei, key });
     } else {
+      const isTrack =
+        event.messageCode === 0 ||
+        event.messageCode === 10 ||
+        event.messageCode === 11 ||
+        event.messageCode === 12;
       log({
         event: "non_free_text",
         level: "info",
         imei: event.imei,
         messageCode: event.messageCode,
         key,
+        // Diagnostic: when LOG_TRACK_PAYLOADS=true, attach the full tracking
+        // event so a fixture can be reconstructed from logs. Silent-drop
+        // policy is unchanged — this only affects the log line's content.
+        ...(isTrack && logTrackPayloads(env) ? { payload: event } : {}),
       });
     }
     return;

--- a/src/env.ts
+++ b/src/env.ts
@@ -27,6 +27,7 @@ export interface Env {
   IPC_SCHEMA_VERSION: string;
   IPC_INBOUND_SENDER: string;
   IPC_INBOUND_DRY_RUN: string;
+  LOG_TRACK_PAYLOADS: string;
   RESEND_FROM_EMAIL: string;
   RESEND_FROM_NAME: string;
   JOURNAL_POST_PATH_TEMPLATE: string;
@@ -87,6 +88,7 @@ export const EnvSchema = z.object({
   IPC_SCHEMA_VERSION: z.enum(["2", "3", "4"]),
   IPC_INBOUND_SENDER: z.string().min(1),
   IPC_INBOUND_DRY_RUN: z.string(),
+  LOG_TRACK_PAYLOADS: z.string(),
   RESEND_FROM_EMAIL: z.string().email(),
   RESEND_FROM_NAME: z.string().min(1),
   JOURNAL_POST_PATH_TEMPLATE: z.string().min(1),
@@ -167,6 +169,16 @@ export function appendCostSuffix(env: Env): boolean {
  */
 export function ipcInboundDryRun(env: Env): boolean {
   return env.IPC_INBOUND_DRY_RUN.toLowerCase() === "true";
+}
+
+/**
+ * Parse LOG_TRACK_PAYLOADS. When true, `non_free_text` log lines for tracking
+ * events (messageCode 0/10/11/12) carry the full event JSON so a fixture can
+ * be reconstructed from logs during a real device session. Default off; the
+ * silent-drop policy is unchanged either way.
+ */
+export function logTrackPayloads(env: Env): boolean {
+  return env.LOG_TRACK_PAYLOADS.toLowerCase() === "true";
 }
 
 /** Parse DAILY_TOKEN_BUDGET (0 = unlimited). */

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -179,6 +179,82 @@ describe("Worker /garmin/ipc — intercept policy (PRD §8 D10, #122)", () => {
   });
 });
 
+describe("Worker /garmin/ipc — LOG_TRACK_PAYLOADS diagnostic", () => {
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  function trackEvent(messageCode: number) {
+    return {
+      Version: "2.0",
+      Events: [
+        {
+          imei: "123456789012345",
+          messageCode,
+          timeStamp: 1739753925000,
+          point: {
+            latitude: 34.0379,
+            longitude: -118.6916,
+            altitude: 12,
+            gpsFix: 2,
+            course: 215,
+            speed: 8.4,
+          },
+          status: { autonomous: 1, lowBattery: 0, intervalChange: 0, resetDetected: 0 },
+        },
+      ],
+    };
+  }
+
+  function nonFreeTextLogs(): Array<Record<string, unknown>> {
+    return consoleLog.mock.calls
+      .map((args) => {
+        try {
+          return JSON.parse(String(args[0])) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is Record<string, unknown> => entry?.event === "non_free_text");
+  }
+
+  test("default (LOG_TRACK_PAYLOADS=false): non_free_text log omits payload", async () => {
+    const res = await postIpc(trackEvent(0), { bearer: env.GARMIN_INBOUND_TOKEN });
+    expect(res.status).toBe(200);
+    const logs = nonFreeTextLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).not.toHaveProperty("payload");
+    expect(logs[0].messageCode).toBe(0);
+  });
+
+  test.each([0, 10, 11, 12])(
+    "LOG_TRACK_PAYLOADS=true: messageCode %i carries full event payload in log",
+    async (messageCode) => {
+      env = makeTestEnv({ LOG_TRACK_PAYLOADS: "true" });
+      const res = await postIpc(trackEvent(messageCode), {
+        bearer: env.GARMIN_INBOUND_TOKEN,
+      });
+      expect(res.status).toBe(200);
+      const logs = nonFreeTextLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toHaveProperty("payload");
+      expect((logs[0].payload as { messageCode: number }).messageCode).toBe(messageCode);
+      expect((logs[0].payload as { point?: { latitude: number } }).point?.latitude).toBe(34.0379);
+    },
+  );
+
+  test("LOG_TRACK_PAYLOADS=true does NOT attach payload for non-tracking codes (e.g. 64)", async () => {
+    env = makeTestEnv({ LOG_TRACK_PAYLOADS: "true" });
+    const res = await postIpc(trackEvent(64), { bearer: env.GARMIN_INBOUND_TOKEN });
+    expect(res.status).toBe(200);
+    const logs = nonFreeTextLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).not.toHaveProperty("payload");
+  });
+});
+
 describe("Worker sanity routes", () => {
   test("GET / returns banner", async () => {
     const res = await app.request("/", {}, env);

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -74,6 +74,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     IPC_SCHEMA_VERSION: "2",
     IPC_INBOUND_SENDER: "trailscribe@resend.dev",
     IPC_INBOUND_DRY_RUN: "false",
+    LOG_TRACK_PAYLOADS: "false",
     RESEND_FROM_EMAIL: "trailscribe@resend.dev",
     RESEND_FROM_NAME: "TrailScribe",
     JOURNAL_POST_PATH_TEMPLATE: "_posts/{yyyy}-{mm}-{dd}-{slug}.md",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,6 +26,11 @@ DAILY_TOKEN_BUDGET = "50000"
 IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
 IPC_INBOUND_DRY_RUN = "false"
+# Diagnostic: when "true", log full payload of non-Free-Text events (tracking
+# pings, Start/Stop Track, etc.) so a fixture can be reconstructed from logs
+# during a real device session. Default off — the silent-drop policy still
+# applies; this just changes what the drop log line carries.
+LOG_TRACK_PAYLOADS = "false"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
@@ -99,6 +104,7 @@ IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
 # delivering real SMS to the operator's device. Production deploys are
 # blocked from setting this — see src/env.ts parseEnv guard.
 IPC_INBOUND_DRY_RUN = "false"
+LOG_TRACK_PAYLOADS = "false"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe (staging)"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
@@ -148,6 +154,7 @@ IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
 # Production must always deliver. parseEnv throws if this is "true" + env=production.
 IPC_INBOUND_DRY_RUN = "false"
+LOG_TRACK_PAYLOADS = "false"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"


### PR DESCRIPTION
## Summary

- Adds `LOG_TRACK_PAYLOADS` (default `"false"`) — when on, the existing `non_free_text` log line for tracking events (`messageCode` 0/10/11/12) carries the full event JSON.
- Lets us replay a real device tracking session into a fixture from logs alone, ahead of the tracking-session-artifacts work in `docs/superpowers/specs/2026-05-01-tracking-session-artifacts-design.md`.
- Silent-drop policy unchanged. Non-tracking codes (encrypted-binary 64, generic-binary 66, etc.) stay payload-less even with the flag on — no point leaking opaque blobs into Workers Logs.

## Why this is needed

The 2026-05-02 test session (PCH/Malibu out-and-back) confirmed the Worker receives tracking pings end-to-end, but the existing `non_free_text` log line drops everything except `{imei, messageCode, key}` — so we can verify *that* events arrived but can't reconstruct the per-ping `{lat, lon, alt, speed, course, lowBattery}` payload that the spec's session-state machine and metric pipeline need to be tested against.

This flag is a one-walk diagnostic: flip on, do a tracking session, lift the fixture out of `wrangler tail`, flip back off.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 338 passed (6 new tests in `app.test.ts`)
- [x] New tests cover: default omits payload; flag-on attaches payload for codes 0/10/11/12; flag-on does NOT attach payload for non-tracking code 64
- [ ] Manual: deploy to staging with flag on; do a 5-minute tracking walk; confirm `wrangler tail` shows `payload` key in `non_free_text` log lines; flip flag back off

🤖 Generated with [Claude Code](https://claude.com/claude-code)