### PR TITLE
feat(tracking): inner-LLM checkpoint to bound cost on deterministic failures (#172)

### DIFF
--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -53,7 +53,8 @@ export type OpName =
   | "share"
   | "blast"
   | "image"
-  | "publish_track";
+  | "publish_track"
+  | "track_narrative";
 
 /**
  * Message-lifecycle record stored under `idem:<key>` (PRD §5).

--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -54,10 +54,12 @@ export async function handleStopTrack(
   env: Env,
   idemKey: string,
 ): Promise<void> {
-  // Single coarse checkpoint per spec §6.1 — trades partial-failure granularity
-  // (we re-run the LLM if anything after publishTrackPost fails) for simpler
-  // reasoning about publish_track being all-or-nothing. See commands/post.ts for
-  // the per-op pattern used by !post; the divergence is intentional, not drift.
+  // Outer `publish_track` checkpoint owns the all-or-nothing publish lifecycle
+  // (publish + store + reply) per spec §6.1. Inner `track_narrative` checkpoint
+  // (added per #172) bounds LLM cost on deterministic-failure retries: after a
+  // successful narrative call, a downstream publish/reply failure won't burn
+  // another Sonnet call when Garmin retries the webhook (2/4/8/16/32/64/128s
+  // then 12h × 5d). Mirrors the per-op pattern in commands/post.ts.
   await withCheckpoint(env, idemKey, "publish_track", async () => {
     const closedAt = event.timeStamp;
     const lookbackHours = Number.parseInt(env.TRACK_LOOKBACK_HOURS, 10) || 12;
@@ -102,13 +104,15 @@ export async function handleStopTrack(
       log({ event: "track_enrichment_failed", level: "warn", kind: "weather", imei: event.imei, error: String(weatherSettled.reason) });
     }
 
-    const narrative = await generateTrackNarrative({
-      metrics,
-      startPlace: typeof startPlace === "string" ? startPlace : undefined,
-      endPlace: typeof endPlace === "string" ? endPlace : undefined,
-      weatherSummary: typeof weather === "string" ? weather : undefined,
-      env,
-    });
+    const narrative = await withCheckpoint(env, idemKey, "track_narrative", () =>
+      generateTrackNarrative({
+        metrics,
+        startPlace: typeof startPlace === "string" ? startPlace : undefined,
+        endPlace: typeof endPlace === "string" ? endPlace : undefined,
+        weatherSummary: typeof weather === "string" ? weather : undefined,
+        env,
+      }),
+    );
 
     await recordTransaction({
       command: "post",

--- a/tests/tracking.test.ts
+++ b/tests/tracking.test.ts
@@ -295,6 +295,47 @@ describe("handleStopTrack — end to end", () => {
     expect(vi.mocked(sendReply).mock.calls[0][1][0]).toContain("no breadcrumbs");
   });
 
+  test("inner-LLM checkpoint: narrative cached when publish fails, re-run avoids fresh LLM call (#172)", async () => {
+    const env = makeTestEnv();
+    vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(FIXTURE_KML_E2E);
+    vi.spyOn(geocodeMod, "reverseGeocode")
+      .mockResolvedValue("Malibu, CA");
+    vi.spyOn(weatherMod, "currentWeather").mockResolvedValue("Sunny, 18°C");
+    const narrativeSpy = vi.spyOn(narrativeMod, "generateTrackNarrative").mockResolvedValue({
+      title: "PCH and back",
+      haiku: "a\nb\nc",
+      body: "Run + beach + return.",
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
+    });
+    // First publish call throws (e.g. journal PAT expired); second succeeds.
+    const publishSpy = vi.spyOn(publishMod, "publishTrackPost")
+      .mockRejectedValueOnce(new Error("403 Bad credentials"))
+      .mockResolvedValueOnce({
+        url: "https://brockamer.github.io/trailscribe-journal/2026/05/02/pch.html",
+        path: "_posts/2026-05-02-pch.md",
+        sha: "abc",
+      });
+
+    const stopEvent: GarminEvent = {
+      imei: "300052030374220",
+      messageCode: 12,
+      timeStamp: Date.parse("2026-05-02T16:24:30Z"),
+    };
+
+    // First call: narrative succeeds, publish throws → outer checkpoint
+    // doesn't cache `publish_track`, but inner `track_narrative` IS cached.
+    await expect(handleStopTrack(stopEvent, env, "idem-cost-bound")).rejects.toThrow(/Bad credentials/);
+    expect(narrativeSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+
+    // Second call (Garmin retry): narrative cache hit → LLM NOT re-called;
+    // publish runs again and succeeds this time.
+    await handleStopTrack(stopEvent, env, "idem-cost-bound");
+    expect(narrativeSpy).toHaveBeenCalledTimes(1); // <-- the bound: still 1, not 2
+    expect(publishSpy).toHaveBeenCalledTimes(2);
+    expect(sendReply).toHaveBeenCalledTimes(1);
+  });
+
   test("idempotent on replay: second handleStopTrack call short-circuits", async () => {
     const env = makeTestEnv();
     vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(FIXTURE_KML_E2E);


### PR DESCRIPTION
## Summary

- Wrap `generateTrackNarrative` in `handleStopTrack` with a nested `withCheckpoint(..., "track_narrative", ...)` so deterministic-failure retries (Garmin's 2/4/8/16/32/64/128s + 12h × 5d schedule) reuse the cached narrative instead of burning a fresh Sonnet call. Worst case before: ~13 fresh LLM calls per stuck Stop Track event. After: 1.
- Mirrors the per-op pattern in `commands/post.ts` (`narrative` + `publish` checkpoints on the `!post` path). The outer `publish_track` checkpoint stays — narrows granularity, doesn't replace it.
- Adds `track_narrative` to the `OpName` enumerated allowlist in `idempotency.ts` (typo guard for new op buckets).

Closes #172.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 389/389 (was 388; +1 regression test for this issue)
- [x] New test asserts the *bound* — `expect(narrativeSpy).toHaveBeenCalledTimes(1)` checked twice (before + after a retry), so a regression that re-invokes the LLM lights up immediately
- [ ] Production behavior change is invisible until a real Stop Track event hits a deterministic failure mid-pipeline; no runtime regression on the happy path or on existing replay-short-circuit semantics

## Notes

- The handoff prompt (`tmp/next-session-prompt-2026-05-04-0419.md`) called this out as the cleanest single-PR code-only option. Picked it as the next pull after #177's MapShare URL fix.
- Independent of the still-open Garmin-side KML feed 302 regression — that needs operator portal investigation. End-to-end production verification of the tracking pipeline still gates on resolving that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)