### PR TITLE
feat(mapshare): support Basic Auth on access-code-protected KML feed

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -53,3 +53,14 @@ ADDRESS_BOOK_JSON=
 # Same `echo -n "<token>" | wrangler secret put IMAGE_API_KEY --env <env>` rule
 # as other secrets — strip trailing newlines.
 IMAGE_API_KEY=
+
+# ---- MapShare KML feed (tracking session artifacts) ----
+# Per-tenant Garmin MapShare slug; the path component appended to MAPSHARE_BASE.
+# Find at explore.garmin.com → MapShare → Page name.
+MAPSHARE_KEY=trailscribe
+
+# Access code that protects the MapShare KML feed (HTTP Basic Auth password;
+# username is ignored). Set in explore.garmin.com → MapShare → Access Code.
+# Empty string = unprotected feed (no auth header sent). Pipe with echo -n
+# to strip trailing newlines: `echo -n "<code>" | wrangler secret put MAPSHARE_PASSWORD --env <env>`.
+MAPSHARE_PASSWORD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ plans/                          # per-milestone sprint plans (active: phase-2-ex
 - `GITHUB_JOURNAL_BRANCH` — `main`
 - `IMAGE_API_KEY` — image-gen provider API key (Replicate token in α; `!postimg` only)
 - `ADDRESS_BOOK_JSON` — alias map for `!share`/`!blast` (Phase 2; e.g. `{"aliases":{"home":"...","all":"a@x,b@y"}}`)
+- `MAPSHARE_KEY` — per-tenant MapShare slug (path component appended to `MAPSHARE_BASE`); `trailscribe` for prod
+- `MAPSHARE_PASSWORD` — MapShare access code (Basic Auth password; empty user). Set in Garmin Explore → MapShare → Access Code. Empty string = unprotected feed (no auth header).
 
 **Vars (non-secret):**
 - `TRAILSCRIBE_ENV` — dev/staging/production

--- a/src/adapters/location/mapshare.ts
+++ b/src/adapters/location/mapshare.ts
@@ -118,9 +118,17 @@ export async function fetchMapShareKml(
   const d1 = new Date(startedAtMs).toISOString();
   const d2 = new Date(closedAtMs).toISOString();
   const url = `${env.MAPSHARE_BASE}/Feed/Share/${env.MAPSHARE_KEY}?d1=${d1}&d2=${d2}`;
-  const res = await fetch(url, {
-    headers: { Accept: "application/vnd.google-earth.kml+xml" },
-  });
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.google-earth.kml+xml",
+  };
+  if (env.MAPSHARE_PASSWORD.length > 0) {
+    // Garmin MapShare access codes use HTTP Basic Auth with the access code as
+    // the password — username is ignored (empty works). Verified 2026-05-04
+    // against the production trailscribe MapShare with access code set:
+    // `curl -u ":<code>"` returns 200 + KML; no auth returns 401.
+    headers.Authorization = `Basic ${btoa(`:${env.MAPSHARE_PASSWORD}`)}`;
+  }
+  const res = await fetch(url, { headers });
   if (!res.ok) {
     log({
       event: "mapshare_fetch_failed",

--- a/src/env.ts
+++ b/src/env.ts
@@ -55,6 +55,7 @@ export interface Env {
   ADDRESS_BOOK_JSON: string;
   IMAGE_API_KEY: string;
   MAPSHARE_KEY: string;
+  MAPSHARE_PASSWORD: string;
 }
 
 /**
@@ -134,6 +135,11 @@ export const EnvSchema = z.object({
   }),
   IMAGE_API_KEY: z.string().min(8),
   MAPSHARE_KEY: z.string().min(1),
+  // MapShare access code (Basic Auth password). Empty string allowed for
+  // unprotected feeds; non-empty value triggers `Authorization: Basic` header
+  // construction in fetchMapShareKml. Set via Garmin Explore portal → MapShare
+  // → Access Code.
+  MAPSHARE_PASSWORD: z.string(),
 });
 
 /**

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -101,6 +101,7 @@ export function makeTestEnv(overrides: Partial<Env> = {}): Env {
     ADDRESS_BOOK_JSON: "",
     IMAGE_API_KEY: "test-image-api-key",
     MAPSHARE_KEY: "trailscribe",
+    MAPSHARE_PASSWORD: "",
   };
   return { ...base, ...overrides };
 }

--- a/tests/mapshare.test.ts
+++ b/tests/mapshare.test.ts
@@ -130,4 +130,29 @@ describe("fetchMapShareKml", () => {
       expect((e as MapShareError).status).toBe(503);
     }
   });
+
+  test("MAPSHARE_PASSWORD empty: no Authorization header sent", async () => {
+    const env = makeTestEnv({ MAPSHARE_PASSWORD: "" });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("<kml/>", { status: 200 }));
+    await fetchMapShareKml(env, 0, 1);
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as
+      | Record<string, string>
+      | undefined;
+    expect(headers?.Authorization).toBeUndefined();
+    expect(headers?.Accept).toBe("application/vnd.google-earth.kml+xml");
+  });
+
+  test("MAPSHARE_PASSWORD set: sends Basic Auth with empty user + password (#175)", async () => {
+    const env = makeTestEnv({ MAPSHARE_PASSWORD: "headquarters" });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("<kml/>", { status: 200 }));
+    await fetchMapShareKml(env, 0, 1);
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as
+      Record<string, string>;
+    // Basic <base64(":headquarters")> = Basic OmhlYWRxdWFydGVycw==
+    expect(headers.Authorization).toBe(`Basic ${btoa(":headquarters")}`);
+  });
 });


### PR DESCRIPTION
## Summary

Adds `MAPSHARE_PASSWORD` secret + `Authorization: Basic` header construction in `fetchMapShareKml`. Empty value preserves the unprotected-feed code path; non-empty value sends Basic Auth with empty username + password = the access code, matching Garmin's documented protocol.

Companion to PR #178 (URL composition fix). Together they restore the end-to-end Stop Track → KML → narrative → publish path that #175's close-gate caught failing on 2026-05-04.

## Why this is needed

Operator confirmed in this session that the production MapShare's KML feed had been turned off and now has an access code (`headquarters`). Empirical curl probe before writing code:

| Auth | Result |
|---|---|
| No auth | HTTP 401 |
| `curl -u ":headquarters"` (empty user, password) | HTTP 200, 37,435 bytes, `application/vnd.google-earth.kml+xml` |
| `curl -u "headquarters:headquarters"` | HTTP 200 (username ignored) |
| `?password=headquarters` query string | HTTP 401 (not supported) |

Garmin's official KML Feeds doc confirms: *"If the MapShare settings indicate a username or password, those must be provided using Basic HTTP Authentication."*

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 391/391 (was 389; +2 for the auth header coverage — empty/non-empty branches)
- [ ] After merge: auto-deploy lands the code; then `echo -n "headquarters" | wrangler secret put MAPSHARE_PASSWORD --env staging` + same for production. Verify with a manual curl against the worker's URL composition or the next Stop Track event.

## URL host note

Garmin's doc names the canonical host `inreach.garmin.com/feed/share/<id>`. Our `MAPSHARE_BASE` resolves to `share.garmin.com/Feed/Share/<id>`. Both return identical KML against the same access-code header — verified just now with curl. Not switching hosts in this PR; if Garmin ever deprecates the alias we'll need a one-line wrangler.toml change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)