### PR TITLE
fix(tracking): refuse to publish on Stop without active session start (#175)

### DIFF
--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -15,7 +15,6 @@ import { currentWeather } from "../adapters/location/weather.js";
 
 const TRACK_RECORD_TTL_SECONDS = 60 * 60 * 24 * 365;
 const TRACK_START_TTL_SECONDS = 60 * 60 * 24;
-const MS_PER_HOUR = 60 * 60 * 1000;
 
 interface TrackStartRecord {
   startedAt: number;
@@ -105,17 +104,32 @@ export async function handleStopTrack(
   // then 12h × 5d). Mirrors the per-op pattern in commands/post.ts.
   await withCheckpoint(env, idemKey, "publish_track", async () => {
     const closedAt = event.timeStamp;
-    // Prefer the recorded mc 10 start over the lookback heuristic — without
-    // this, closely-spaced Stop Tracks all query overlapping 12h windows and
-    // pull the same breadcrumbs, producing duplicate/conflated narratives.
+    // The session window is bounded by a recorded mc 10 (Start Track) only.
+    // Lookback fallback was removed — it produced wrong narratives by pulling
+    // unrelated breadcrumbs (e.g. a 100km drive earlier in the day) when a
+    // Stop arrived without a preceding Start (operator pressed Stop twice,
+    // device emitted Stop on its own, or Iridium delivered Stop before Start).
     const startRecord = await readSessionStart(env, event.imei);
-    const lookbackHours = Number.parseInt(env.TRACK_LOOKBACK_HOURS, 10) || 12;
-    const startedAt = startRecord?.startedAt ?? closedAt - lookbackHours * MS_PER_HOUR;
+    if (!startRecord) {
+      log({
+        event: "track_stop_no_active_session",
+        level: "warn",
+        imei: event.imei,
+        idemKey,
+        closedAt,
+      });
+      await sendReply(
+        event.imei,
+        ["Track ended; no active session — press Start before tracking next time."],
+        env,
+      );
+      return { skipped: "no_active_session" };
+    }
+    const startedAt = startRecord.startedAt;
     log({
       event: "track_session_window",
       level: "info",
       imei: event.imei,
-      source: startRecord ? "start_record" : "lookback",
       startedAt,
       closedAt,
     });

--- a/tests/tracking.test.ts
+++ b/tests/tracking.test.ts
@@ -249,27 +249,27 @@ describe("session start window (#175 follow-up)", () => {
     expect(callArgs[2]).toBe(closedAt);
   });
 
-  test("Stop Track without a recorded start falls back to TRACK_LOOKBACK_HOURS", async () => {
-    const env = makeTestEnv({ TRACK_LOOKBACK_HOURS: "6" });
-    const fetchMock = vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(FIXTURE_KML_E2E);
-    vi.spyOn(narrativeMod, "generateTrackNarrative").mockResolvedValue({
-      title: "x", haiku: "a\nb\nc", body: "y",
-      usage: { prompt_tokens: 1, completion_tokens: 1 },
-    });
-    vi.spyOn(publishMod, "publishTrackPost").mockResolvedValue({
-      url: "https://x", path: "p", sha: "s",
-    });
+  test("Stop Track without a recorded start refuses to publish (no lookback fallback)", async () => {
+    vi.mocked(sendReply).mockClear();
+    const env = makeTestEnv();
+    const mapshareSpy = vi.spyOn(mapshareMod, "fetchMapShareKml");
+    const narrativeSpy = vi.spyOn(narrativeMod, "generateTrackNarrative");
+    const publishSpy = vi.spyOn(publishMod, "publishTrackPost");
 
-    const closedAt = Date.parse("2026-05-04T22:05:00Z");
+    const closedAt = Date.parse("2026-05-04T22:43:45Z");
     await handleStopTrack(
       { imei: "300052030374220", messageCode: 12, timeStamp: closedAt },
       env,
-      "idem-fallback-1",
+      "idem-no-start",
     );
 
-    const callArgs = fetchMock.mock.calls[0];
-    expect(callArgs[1]).toBe(closedAt - 6 * 60 * 60 * 1000);
-    expect(callArgs[2]).toBe(closedAt);
+    // None of the publish-pipeline side effects should fire.
+    expect(mapshareSpy).not.toHaveBeenCalled();
+    expect(narrativeSpy).not.toHaveBeenCalled();
+    expect(publishSpy).not.toHaveBeenCalled();
+    // Operator gets the no-active-session SMS reply.
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendReply).mock.calls[0][1][0]).toContain("no active session");
   });
 
   test("Stop Track clears the start record so the next Stop without a fresh Start uses fallback", async () => {
@@ -305,8 +305,17 @@ describe("handleStopTrack — end to end", () => {
     vi.mocked(sendReply).mockResolvedValue({ count: 1 });
   });
 
+  // Helper: seed a fresh mc 10 (Start Track) record before each handleStopTrack
+  // invocation, since the production path always requires this — there is no
+  // longer a lookback fallback (#175 fix).
+  async function seedSessionStart(env: ReturnType<typeof makeTestEnv>, imei: string, atMs: number) {
+    const { recordSessionStart } = await import("../src/core/tracking.js");
+    await recordSessionStart(env, imei, atMs);
+  }
+
   test("fetches KML, generates narrative, publishes, replies, persists record", async () => {
     const env = makeTestEnv();
+    await seedSessionStart(env, "300052030374220", Date.parse("2026-05-02T15:51:30Z"));
     vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(FIXTURE_KML_E2E);
     vi.spyOn(geocodeMod, "reverseGeocode")
       .mockResolvedValueOnce("Malibu, CA")  // start
@@ -359,11 +368,13 @@ describe("handleStopTrack — end to end", () => {
 
   test("empty KML: logs warning, sends 'no breadcrumbs' reply, no publish", async () => {
     const env = makeTestEnv();
+    const closedAt = Date.now();
+    await seedSessionStart(env, "300052030374220", closedAt - 5 * 60 * 1000);
     vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue("<kml/>");
     const publishSpy = vi.spyOn(publishMod, "publishTrackPost");
 
     await handleStopTrack(
-      { imei: "300052030374220", messageCode: 12, timeStamp: Date.now() },
+      { imei: "300052030374220", messageCode: 12, timeStamp: closedAt },
       env,
       "idem-key-2",
     );
@@ -375,6 +386,7 @@ describe("handleStopTrack — end to end", () => {
 
   test("inner-LLM checkpoint: narrative cached when publish fails, re-run avoids fresh LLM call (#172)", async () => {
     const env = makeTestEnv();
+    await seedSessionStart(env, "300052030374220", Date.parse("2026-05-02T15:51:30Z"));
     vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(FIXTURE_KML_E2E);
     vi.spyOn(geocodeMod, "reverseGeocode")
       .mockResolvedValue("Malibu, CA");
@@ -416,6 +428,7 @@ describe("handleStopTrack — end to end", () => {
 
   test("idempotent on replay: second handleStopTrack call short-circuits", async () => {
     const env = makeTestEnv();
+    await seedSessionStart(env, "300052030374220", Date.parse("2026-05-02T15:51:30Z"));
     vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(FIXTURE_KML_E2E);
     vi.spyOn(narrativeMod, "generateTrackNarrative").mockResolvedValue({
       title: "x", haiku: "a\nb\nc", body: "y",


### PR DESCRIPTION
## Summary

The 2026-05-04 close-gate testing surfaced a second-order bug after PR #182's mc 10 → d1 fix: when an operator pressed Stop *without* a fresh Start preceding it, \`handleStopTrack\` fell back to the 12-hour lookback heuristic and pulled the entire day's worth of breadcrumbs — including a 100km drive from hours earlier — producing a journal post about a session the operator never intended.

Root cause is captured in the commit message and tracked in the conversation transcript (KV inspection showed both 100km records had \`startedAt = 14:07:15Z\`, exactly the lookback-window edge — that's the lookback fingerprint, not a real session start).

Fix: drop the lookback fallback. When no \`track_start:<imei>\` KV record exists at Stop time, refuse to publish, log \`track_stop_no_active_session\` warning, send the operator an SMS ("Track ended; no active session — press Start before tracking next time."), and return.

## Why refuse instead of shorter lookback

A 30-minute or 1-hour fallback still produces wrong narratives if the operator happened to be moving recently — the bug is "publish from inferred window" and shortening the window only shrinks the blast radius. Wrong data is worse than missing data.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 393/393
- [x] All four existing \`handleStopTrack\` end-to-end tests now seed a session start via \`recordSessionStart\` before invoking — this reflects the production-required pre-condition (which is what reality enforces anyway, post-fix)
- [x] New test \`Stop Track without a recorded start refuses to publish\` asserts no MapShare/narrative/publish side effects fire and the SMS reply contains "no active session"
- [ ] After deploy: pressing Stop with no recent Start should produce only the SMS reply, no journal commit, no TS_TRACKS write

## Cleanup pending

The 2 duplicate ~100km posts already on the journal (\`e949200\` "Hundred Kilometers" and \`21ec4c3\` "Slow Read") plus their TS_TRACKS records can be deleted post-merge in the same pattern as the previous close-gate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)