### PR TITLE
fix(tracking): neutral SMS wording on no-active-session reply

### DIFF
--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -120,7 +120,7 @@ export async function handleStopTrack(
       });
       await sendReply(
         event.imei,
-        ["Track ended; no active session — press Start before tracking next time."],
+        ["Track ended; no active session was recorded — nothing to publish."],
         env,
       );
       return { skipped: "no_active_session" };


### PR DESCRIPTION
## Summary

Operator correction: the previous SMS reply text \"Track ended; no active session — press Start before tracking next time.\" referenced a button that doesn't match the device UI as actually used. Replaced with neutral fact-only wording: \"Track ended; no active session was recorded — nothing to publish.\"

\`pnpm test\` 393/393 (test assertion still on \"no active session\" substring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)