### PR TITLE
feat(ledger): disaggregate track LLM cost into a separate "track" bucket (#173)

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -95,10 +95,14 @@ function helpText(): string {
 }
 
 /**
- * Format the `!cost` reply body. Per plan P1-19:
+ * Format the `!cost` reply body. Summary line follows plan P1-19:
  *   "<requests> req · <tokens>k tok · $<cost> (since <YYYY-MM-01>)"
- * Tokens are summed (prompt + completion) and rendered in thousands with one
- * decimal. Total width capped at ~52 chars in realistic ranges.
+ * When the ledger has any commands with non-zero LLM cost, a second line
+ * renders the per-command breakdown alphabetically:
+ *   "post $0.85 · track $0.38"
+ * Free commands (ping/help/cost/etc.) have $0 and are filtered out so they
+ * don't pollute the breakdown. Two-line composition (not branching returns)
+ * keeps the image-cost variant from drifting from the bare variant. Per #173.
  */
 function formatCostBody(snap: LedgerSnapshot): string {
   const totalTokens = snap.prompt_tokens + snap.completion_tokens;
@@ -106,8 +110,17 @@ function formatCostBody(snap: LedgerSnapshot): string {
   const textCost = snap.usd_cost.toFixed(2);
   const sinceDate = `${snap.period}-01`;
   const imageCost = snap.image_usd_cost ?? 0;
-  if (imageCost > 0) {
-    return `${snap.requests} req · ${tokensK}k tok · $${textCost} + $${imageCost.toFixed(2)} img (since ${sinceDate})`;
-  }
-  return `${snap.requests} req · ${tokensK}k tok · $${textCost} (since ${sinceDate})`;
+
+  const summary =
+    imageCost > 0
+      ? `${snap.requests} req · ${tokensK}k tok · $${textCost} + $${imageCost.toFixed(2)} img (since ${sinceDate})`
+      : `${snap.requests} req · ${tokensK}k tok · $${textCost} (since ${sinceDate})`;
+
+  const breakdown = Object.entries(snap.by_command)
+    .filter(([, v]) => v.usd_cost > 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([cmd, v]) => `${cmd} $${v.usd_cost.toFixed(2)}`)
+    .join(" · ");
+
+  return breakdown ? `${summary}\n${breakdown}` : summary;
 }

--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -184,7 +184,7 @@ export async function handleStopTrack(
     );
 
     await recordTransaction({
-      command: "post",
+      command: "track",
       usage: narrative.usage,
       env,
     });

--- a/tests/p1-19-commands.test.ts
+++ b/tests/p1-19-commands.test.ts
@@ -161,7 +161,69 @@ describe("P1-19 — !cost", () => {
 
     const [, messages] = sendReplyMock.mock.calls[0];
     // 2000 tokens total → "2.0k tok"; 1500*0.0001 + 500*0.0003 = 0.15 + 0.15 = $0.30
-    expect(messages[0]).toMatch(/^1 req · 2\.0k tok · \$0\.30 \(since \d{4}-\d{2}-01\)$/);
+    // Two-line render (#173): summary then per-command breakdown.
+    const [summary, breakdown] = messages[0].split("\n");
+    expect(summary).toMatch(/^1 req · 2\.0k tok · \$0\.30 \(since \d{4}-\d{2}-01\)$/);
+    expect(breakdown).toBe("post $0.30");
+  });
+
+  test("multi-command ledger → breakdown lists post + track alphabetically (#173)", async () => {
+    const seedEnv = makeTestEnv({
+      ...env,
+      LLM_INPUT_COST_PER_1K: "0.10",
+      LLM_OUTPUT_COST_PER_1K: "0.30",
+    });
+    await recordTransaction({
+      command: "post",
+      usage: { prompt_tokens: 1500, completion_tokens: 500 },
+      env: seedEnv,
+    });
+    await recordTransaction({
+      command: "track",
+      usage: { prompt_tokens: 1000, completion_tokens: 200 },
+      env: seedEnv,
+    });
+    Object.assign(env, {
+      LLM_INPUT_COST_PER_1K: "0.10",
+      LLM_OUTPUT_COST_PER_1K: "0.30",
+    });
+
+    const res = await postIpc(envelope("!cost"));
+    expect(res.status).toBe(200);
+
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const [summary, breakdown] = messages[0].split("\n");
+    // post: 0.15 + 0.15 = $0.30; track: 0.10 + 0.06 = $0.16; total $0.46.
+    expect(summary).toMatch(/^2 req · 3\.2k tok · \$0\.46 \(since \d{4}-\d{2}-01\)$/);
+    // Alphabetical: post before track.
+    expect(breakdown).toBe("post $0.30 · track $0.16");
+  });
+
+  test("breakdown filters $0-cost commands (ping/help/cost stay invisible) (#173)", async () => {
+    const seedEnv = makeTestEnv({
+      ...env,
+      LLM_INPUT_COST_PER_1K: "0.10",
+      LLM_OUTPUT_COST_PER_1K: "0.30",
+    });
+    await recordTransaction({
+      command: "ping",
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+      env: seedEnv,
+    });
+    await recordTransaction({
+      command: "track",
+      usage: { prompt_tokens: 1000, completion_tokens: 200 },
+      env: seedEnv,
+    });
+    Object.assign(env, {
+      LLM_INPUT_COST_PER_1K: "0.10",
+      LLM_OUTPUT_COST_PER_1K: "0.30",
+    });
+
+    await postIpc(envelope("!cost"));
+    const [, messages] = sendReplyMock.mock.calls[0];
+    const [, breakdown] = messages[0].split("\n");
+    expect(breakdown).toBe("track $0.16");
   });
 
   test("does not record a ledger transaction itself (would skew its own output)", async () => {

--- a/tests/p2-18-postimg.test.ts
+++ b/tests/p2-18-postimg.test.ts
@@ -340,9 +340,14 @@ describe("P2-18 — !cost breakout", () => {
     await postIpc(envelope("!cost"));
 
     const [, messages] = sendReplyMock.mock.calls[0];
-    expect(messages[0]).toMatch(
+    // Two-line render (#173): summary then per-command breakdown.
+    const [summary, breakdown] = messages[0].split("\n");
+    expect(summary).toMatch(
       /^1 req · 1\.5k tok · \$0\.25 \+ \$0\.03 img \(since \d{4}-\d{2}-01\)$/,
     );
+    // recordImageTransaction doesn't touch by_command, so only the post entry
+    // appears in the breakdown.
+    expect(breakdown).toBe("post $0.25");
   });
 
   test("no image entries → !cost reply preserves Phase 1 format", async () => {

--- a/tests/tracking.test.ts
+++ b/tests/tracking.test.ts
@@ -9,6 +9,7 @@ import { chatCompletion } from "../src/adapters/ai/openrouter.js";
 import { makeTestEnv } from "./helpers/env.js";
 import { publishTrackPost } from "../src/adapters/publish/github-pages.js";
 import { sendReply } from "../src/adapters/outbound/garmin-ipc-inbound.js";
+import { monthlyTotals } from "../src/core/ledger.js";
 import * as mapshareMod from "../src/adapters/location/mapshare.js";
 import * as narrativeMod from "../src/core/narrative.js";
 import * as publishMod from "../src/adapters/publish/github-pages.js";
@@ -364,6 +365,12 @@ describe("handleStopTrack — end to end", () => {
     expect(stored).not.toBeNull();
     expect(stored.pingCount).toBe(14);
     expect(stored.journalUrl).toBe("https://brockamer.github.io/trailscribe-journal/2026/05/02/pch.html");
+
+    // #173: LLM cost records under by_command.track (not .post) so !cost can
+    // disaggregate publish-class commands.
+    const ledger = await monthlyTotals(env);
+    expect(ledger.by_command.track).toMatchObject({ requests: 1 });
+    expect(ledger.by_command.post).toBeUndefined();
   });
 
   test("empty KML: logs warning, sends 'no breadcrumbs' reply, no publish", async () => {


### PR DESCRIPTION
## Summary

Closes #173.

- Stop Track flow (`src/core/tracking.ts`) records LLM cost under `command: "track"` instead of `"post"`, so `!cost` and any cost telemetry can disaggregate publish-class commands.
- `formatCostBody` (`src/core/orchestrator.ts`) renders a second line with the per-command breakdown when any command has non-zero LLM cost:

  ```
  12 req · 8.4k tok · $1.23 (since 2026-05-01)
  post $0.85 · track $0.38
  ```

  Composes summary + breakdown (one return composition site) instead of branching the return — keeps the image-cost variant from drifting from the bare variant.

- Breakdown filters `usd_cost > 0` (free commands like `!ping`/`!help`/`!cost` stay invisible) and sorts alphabetically for deterministic test assertions.
- `LedgerEntry.command` was already typed `string` (not a narrowed literal union), so no typing change needed.

## User-visible change

`!cost` reply gains a second line. Total reply width in realistic ranges: ~80 chars, well under the 320-char two-SMS reply budget.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 395/395 pass
- [x] `tests/tracking.test.ts` — happy-path Stop Track asserts `by_command.track` is recorded and `.post` is undefined
- [x] `tests/p1-19-commands.test.ts` — existing `^...$` regex split into summary+breakdown assertions; added a multi-command test (alphabetical ordering) and a $0-cost-filtering test
- [x] `tests/p2-18-postimg.test.ts` — image-cost variant's anchored regex split into summary+breakdown
- [ ] Real-device sanity check — next time `!cost` is invoked from the field, confirm the two-line render comes through cleanly via Iridium

🤖 Generated with [Claude Code](https://claude.com/claude-code)