### PR TITLE
docs(prd,field-commands): update !cost reply format example for two-line render (#173)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -329,7 +329,9 @@ If the same webhook replays after partial completion:
 - Recommended: **false** for α (saves 9 chars on every reply), add later after user feedback.
 
 ### Cost visibility
-- `!cost` reply format: `"123 req · 45.2k tok · $1.37 (since 2026-04-01)"` — 46 chars, fits in one SMS.
+- `!cost` reply format: summary line followed by an optional per-command breakdown when any command has non-zero LLM cost (#173).
+  - Summary only (no LLM cost yet): `"0 req · 0.0k tok · $0.00 (since 2026-04-01)"`.
+  - With breakdown: `"2 req · 3.2k tok · $0.46 (since 2026-04-01)\npost $0.30 · track $0.16"` — second line is alphabetical by command, $0-cost commands filtered out. Both lines fit comfortably inside the 320-char reply budget.
 - Monthly budget alerts: Phase 3 feature (needs D1 for historical views).
 
 ---

--- a/docs/field-commands.md
+++ b/docs/field-commands.md
@@ -14,7 +14,7 @@ Keep the device's per-message **Include Location** toggle **off** for routine `!
 |---|---|---|
 | `!ping` | `!ping` | Health check. Replies `pong` to confirm the agent is running. |
 | `!help` | `!help` | Shows the command summary on-device. |
-| `!cost` | `!cost` | Displays the number of requests, total tokens, and cumulative cost since the start of the current month. |
+| `!cost` | `!cost` | Displays the number of requests, total tokens, and cumulative cost since the start of the current month. When any command has accrued LLM cost, a second line lists the per-command breakdown alphabetically (e.g. `post $0.30 · track $0.16`). |
 | `!post` | `!post [note]` | Generates a journal post (title + haiku + body) via OpenRouter and commits it to the GitHub Pages journal repo. Reply links to the live URL. **Bare `!post`** (no caption) builds the narrative purely from device metadata — place name, weather, time — in observational voice, without inventing activities or feelings. |
 | `!postimg` | `!postimg <caption>` | Same as `!post` plus an AI-generated header image. Image-gen via Replicate Flux schnell; markdown + image commit atomically to the journal repo. |
 | `!mail` | `!mail (to\|t):<address> [(subj\|s):<subject>] [(body\|b):<body>]` | Sends an email via Resend to `<address>`. Long keys (`to:`/`subj:`/`body:`) and short aliases (`t:`/`s:`/`b:`) are interchangeable and may be mixed in one message. `subj` and `body` are optional — missing subject defaults to `[TrailScribe]`; missing body yields a footer-only email. Location footer added automatically when GPS is available. |


### PR DESCRIPTION
## Summary

- Docs-only reconciliation following [#188](https://github.com/brockamer/trailscribe/pull/188) (merged in 4341a29), which shipped the per-command cost breakdown on `!cost`.
- Two doc surfaces still referenced the pre-#173 single-line reply format. This PR brings them in line with the actual two-line render produced by `formatCostBody` in `src/core/orchestrator.ts:107-126`.

## Changes

- **`docs/PRD.md` §6 "Cost visibility"** (`docs/PRD.md:331`): replaced the single literal example with two states — empty (summary-only) and populated (two-line with alphabetical per-command breakdown). Explicitly notes the second line is conditional on at least one command having non-zero LLM cost (matches the `usd_cost > 0` filter at `orchestrator.ts:120`). 320-char budget framing preserved.
- **`docs/field-commands.md` command summary** (`docs/field-commands.md:17`): appended a sentence describing the per-command breakdown that now appears as a second line.

## No code change

Verified by `git diff --stat`: `+4 -2`, both lines in `docs/`. Canonical format on the wire is unchanged — this PR only updates documentation to match what `!cost` has been rendering since #188 merged.

## Test plan

- [x] `grep -rn "req · .*tok · \\\$" docs/` returns only the two new examples in `docs/PRD.md`; no stale single-line references remain.
- [x] New PRD example matches the literal output the multi-command test asserts at `tests/p1-19-commands.test.ts:197-199`.
- [ ] Visual review of the rendered table in `docs/field-commands.md` on GitHub to confirm column alignment still reads cleanly.

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)