### PR TITLE
chore: scope `pnpm format` to staged files to prevent diff bloat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Living context file for Claude Code. Keep concise; update as decisions are made.
 - `pnpm dev` — `wrangler dev` local Worker
 - `pnpm test` / `pnpm test:watch` — Vitest
 - `pnpm typecheck` — `tsc --noEmit`
-- `pnpm lint` / `pnpm format`
+- `pnpm lint` — ESLint
+- `pnpm format` — Prettier on **staged files only** (no-op if nothing staged); pass explicit paths to override (`pnpm format docs/PRD.md`). Use `pnpm format:all` for a deliberate whole-repo sweep. Default is scoped per #191 to keep PR diffs tight.
 - `pnpm deploy:staging` / `pnpm deploy:prod`
 
 ## Product
@@ -113,6 +114,7 @@ plans/                          # per-milestone sprint plans (active: phase-2-ex
 ## External services
 
 **Secrets (Wrangler Secrets):**
+
 - `GARMIN_INBOUND_TOKEN` — static token; verify `X-Outbound-Auth-Token: <token>` on Outbound webhooks (Garmin sends raw token in custom header, not standard `Authorization: Bearer`)
 - `GARMIN_IPC_INBOUND_API_KEY` — `X-API-Key` for Garmin IPC Inbound
 - `GARMIN_IPC_INBOUND_BASE_URL` — per-tenant; **host only, no path** (e.g. `https://ipcinbound.inreachapp.com`). Code appends `/api/Messaging/Message`. Found in Garmin Explore → IPC → Inbound Settings → "Inbound URL".
@@ -129,6 +131,7 @@ plans/                          # per-milestone sprint plans (active: phase-2-ex
 - `MAPSHARE_PASSWORD` — MapShare access code (Basic Auth password; empty user). Set in Garmin Explore → MapShare → Access Code. Empty string = unprotected feed (no auth header).
 
 **Vars (non-secret):**
+
 - `TRAILSCRIBE_ENV` — dev/staging/production
 - `GOOGLE_MAPS_BASE` — link prefix for Google Maps URLs
 - `MAPSHARE_BASE` — Garmin MapShare host root (e.g. `https://share.garmin.com`); per-tenant slug lives in `MAPSHARE_KEY` and is appended at use sites (`${MAPSHARE_BASE}/${MAPSHARE_KEY}` for page URLs, `${MAPSHARE_BASE}/Feed/Share/${MAPSHARE_KEY}` for the KML feed). Empty `MAPSHARE_BASE` disables MapShare links in `!where` / `!share` / `!blast`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,12 @@ For Garmin IPC: [`docs/garmin-setup.md`](docs/garmin-setup.md) (requires Profess
 - **TypeScript strict mode**; tests use `.ts` as well.
 - **No `any`** — prefer `unknown` and narrow.
 - **Small exported functions**; JSDoc on every public export.
-- **Prettier** (`pnpm format`) for formatting. Lint config is deferred
-  post-Phase-0.
+- **Prettier** for formatting. `pnpm format` operates on staged files only
+  (no-op if nothing staged); pass explicit paths to override
+  (`pnpm format docs/PRD.md`). `pnpm format:all` runs a whole-repo sweep
+  when intentionally wanted. The staged-by-default behavior keeps PR
+  diffs from absorbing unrelated whitespace drift (see #191). Lint
+  config is deferred post-Phase-0.
 - **Structured logs** via `src/adapters/logging/worker-logs.ts`. No
   `console.log` scattered through the codebase.
 
@@ -58,9 +62,10 @@ bootstrapped for this repo — planned post-Phase-0.
 ## Scope discipline
 
 Do NOT:
+
 - Add a new dependency without PRD justification.
 - Add a new env var / secret without updating `src/env.ts` + `.dev.vars.example`
-  + `wrangler.toml` atomically.
+  - `wrangler.toml` atomically.
 - Bring back Pipedream / n8n integrations (archived as historical paths).
 - Add command verbs outside the α-MVP set (`!ping`, `!help`, `!cost`, `!post`,
   `!mail`, `!todo`) without updating the PRD. Phase 2+ commands are already

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "format": "prettier --write .",
+    "format": "bash scripts/format.sh",
+    "format:all": "prettier --write .",
     "deploy:staging": "wrangler deploy --env staging",
     "deploy:prod": "wrangler deploy --env production"
   },

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/format.sh — scoped Prettier wrapper for trailscribe.
+#
+# Behavior:
+#   pnpm format               → formats files currently staged in git (index)
+#   pnpm format <path> [...]  → formats the explicit paths instead (replaces
+#                               the staged-default)
+#   pnpm format:all           → whole-repo sweep (separate script in
+#                               package.json; bypasses this wrapper)
+#
+# Background: PR #190 (closing #189) was nearly contaminated by a reflexive
+# `prettier --write .` invocation that reformatted ~60 unrelated files,
+# bloating a +4/-2 docs diff to +1068/-840. The repo runs strict
+# PR-per-change with squash merges; a default that respects that discipline
+# is safer than relying on per-invocation vigilance. See #191.
+
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  # Explicit paths win — caller knows what they want formatted.
+  # --ignore-unknown silently skips files Prettier has no parser for
+  # (e.g. shell scripts) so a mixed-extension path list doesn't error.
+  exec pnpm exec prettier --write --ignore-unknown "$@"
+fi
+
+# No args: format only staged files.
+# --diff-filter=ACMR excludes Deleted/Unmerged; -z handles paths with spaces.
+mapfile -d '' staged < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [ "${#staged[@]}" -eq 0 ]; then
+  echo "format: nothing staged; no-op. Use 'pnpm format <path>' for explicit paths or 'pnpm format:all' for a whole-repo sweep."
+  exit 0
+fi
+
+exec pnpm exec prettier --write --ignore-unknown "${staged[@]}"


### PR DESCRIPTION
## Summary

- `pnpm format` now operates on staged files only (no-op when nothing staged), with explicit-path override and `pnpm format:all` as the opt-in whole-repo escape hatch.
- Triggered by the [#189](https://github.com/brockamer/trailscribe/issues/189) wrap session, where a single `pnpm format` invocation reformatted ~60 files mid-PR, bloating a `+4 -2` docs diff to `+1068 -840` and requiring a reset + re-apply.
- Implementation lives in `scripts/format.sh` (35 lines, bash, matches the existing `scripts/*.sh` style).

## What changed

| File | Change |
|---|---|
| `package.json` | `format` → `bash scripts/format.sh`; new `format:all` preserves whole-repo behavior |
| `scripts/format.sh` | New. Branches: explicit paths win; else format staged; else no-op with hint |
| `CLAUDE.md` | `## Commands` updated to explain new semantics + reference #191 |
| `CONTRIBUTING.md` | `## Style` updated to match |

Two benign Markdown normalizations to CLAUDE.md and CONTRIBUTING.md (blank line after bold-label paragraphs, nested-bullet `+`→`-`) got picked up by the first smoke-test of the new script — kept in this PR since both files are in scope anyway.

## Decisions recorded

- **No `lint-staged` / `husky` install.** For a 1-human + 1-AI project, pre-commit hook infrastructure has poor ROI — the original incident was the AI agent reflexively invoking the unscoped command, not a human forgetting to format. Making the default safe IS the fix; a hook would protect against a class of error that didn't actually happen here.
- **Explicit paths replace the staged-default** (Unix expectation). `pnpm format docs/PRD.md` formats only `docs/PRD.md` regardless of index state.
- **`--ignore-unknown` flag added** to both prettier invocations so a staged set containing non-Prettier files (e.g. shell scripts) doesn't trigger a parse error.

## Test plan

- [x] `pnpm format` with nothing staged → exits 0, prints no-op hint.
- [x] `pnpm format` with this PR's 4 files staged → silently skips `scripts/format.sh`, all three Prettier-eligible files report `(unchanged)`, working tree gains zero new diff lines.
- [x] `pnpm format CLAUDE.md` (explicit path) → formats just CLAUDE.md, ignores index.
- [x] Survey confirmed `.github/workflows/ci.yml` runs `pnpm lint` but never `pnpm format`, so CI is unaffected by the script swap.
- [x] No direct `prettier` CLI callers in the repo — the `pnpm format` indirection is the only entry point.

Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)