### PR TITLE
docs(tracking): link Mode B spec + plan to Epic #187 / impl #168

### DIFF
--- a/docs/superpowers/plans/2026-05-03-tracking-session-artifacts.md
+++ b/docs/superpowers/plans/2026-05-03-tracking-session-artifacts.md
@@ -10,6 +10,11 @@
 
 **Spec:** `docs/superpowers/specs/2026-05-01-tracking-session-artifacts-design.md`
 
+## Issue
+
+- #187 — Epic: Tracking Sessions — Mode B hardening (current follow-ups)
+- #168 — Implementation (closed 2026-05-04 — the plan this file describes)
+
 **Reference fixture (real-device, 2026-05-02 PCH session):** `tests/fixtures/mapshare/pch-2026-05-02.kml` (created in Cut 1 — see Task 1.2). 14 individual `<Placemark>` breadcrumbs + 1 trailing LineString summary. Verified live via `curl https://share.garmin.com/Feed/Share/trailscribe?d1=2026-05-02T15:00Z&d2=2026-05-02T17:00Z`.
 
 ---

--- a/docs/superpowers/specs/2026-05-01-tracking-session-artifacts-design.md
+++ b/docs/superpowers/specs/2026-05-01-tracking-session-artifacts-design.md
@@ -3,7 +3,12 @@
 **Status:** Draft, pending review. **Mode B (MapShare pull-on-close) confirmed canonical 2026-05-03.**
 **Author:** Claude (Opus 4.7) with Brock Amer
 **Date:** 2026-05-01 (rewritten 2026-05-03 around MapShare data source — see §0, §13.7)
-**Related:** PRD §9 Roadmap, Epic #99 (Phase 3 — DO + D1, **dependency dropped**), Epic-candidate (this spec → its own new epic)
+**Related:** PRD §9 Roadmap, Epic #99 (Phase 3 — DO + D1, **dependency dropped**), Epic #187 (Tracking Sessions — Mode B hardening)
+
+## Issue
+
+- #187 — Epic: Tracking Sessions — Mode B hardening
+- #168 — Implementation (closed 2026-05-04)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `## Issue` H2 block to `docs/superpowers/plans/2026-05-03-tracking-session-artifacts.md` and `docs/superpowers/specs/2026-05-01-tracking-session-artifacts-design.md`, linking each back to Epic #187 (Mode B hardening) and impl #168 — matches the cross-reference convention used elsewhere in `docs/superpowers/`.
- Replaces the spec's placeholder `Related:` entry ("Epic-candidate (this spec → its own new epic)") with the now-real Epic #187.
- Pure metadata: 11 added lines, 1 removed; no behavior or spec content changes.

## Test plan
- [x] `git diff --stat` shows only the two files; no other churn.
- [x] CI passes (typecheck, lint, tests are all no-op-relevant for docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)