### PR TITLE
feat(reporting): imperial units everywhere; render haikus as 3 lines (#195)

### DIFF
--- a/src/adapters/publish/github-pages.ts
+++ b/src/adapters/publish/github-pages.ts
@@ -1,5 +1,6 @@
 import type { Env } from "../../env.js";
 import type { TrackMetrics } from "../../core/track-metrics.js";
+import { formatHaiku, kmToMi, mToFt } from "../../core/units.js";
 
 const RETRY_DELAYS_MS = [1000, 4000, 16000] as const;
 const MAX_SLUG_COLLISION_ATTEMPTS = 10;
@@ -230,7 +231,7 @@ function renderMarkdown(a: RenderArgs): string {
   }
   lines.push("tags: [trailscribe]");
   lines.push("---");
-  lines.push(a.haiku);
+  lines.push(formatHaiku(a.haiku));
   lines.push("");
   lines.push(a.body);
   return lines.join("\n");
@@ -502,7 +503,7 @@ function renderMarkdownWithImage(a: RenderArgsWithImage): string {
   lines.push("---");
   lines.push(`![${a.title}](${imageUrl})`);
   lines.push("");
-  lines.push(a.haiku);
+  lines.push(formatHaiku(a.haiku));
   lines.push("");
   lines.push(a.body);
   return lines.join("\n");
@@ -592,8 +593,8 @@ function renderTrackMarkdown(a: {
   lines.push(`track:`);
   lines.push(`  started_at: ${new Date(m.startedAt).toISOString()}`);
   lines.push(`  duration_seconds: ${m.durationSeconds}`);
-  lines.push(`  distance_km: ${m.distanceKm.toFixed(2)}`);
-  lines.push(`  elevation_gain_m: ${Math.round(m.elevation.gainM)}`);
+  lines.push(`  distance_mi: ${kmToMi(m.distanceKm).toFixed(2)}`);
+  lines.push(`  elevation_gain_ft: ${Math.round(mToFt(m.elevation.gainM))}`);
   lines.push(`  activity_hint: ${m.activityHint}`);
   lines.push(`  route_shape: ${m.routeShape}`);
   if (a.startPlace !== undefined && a.startPlace !== "") {
@@ -609,7 +610,7 @@ function renderTrackMarkdown(a: {
   if (a.weather !== undefined) lines.push(`weather: ${quoteYaml(a.weather)}`);
   lines.push(`tags: [trailscribe, track]`);
   lines.push("---");
-  lines.push(a.haiku);
+  lines.push(formatHaiku(a.haiku));
   lines.push("");
   lines.push(a.body);
   return lines.join("\n");

--- a/src/core/narrative.ts
+++ b/src/core/narrative.ts
@@ -3,6 +3,7 @@ import type { Env } from "../env.js";
 import { chatCompletion } from "../adapters/ai/openrouter.js";
 import { log } from "../adapters/logging/worker-logs.js";
 import type { TrackMetrics } from "./track-metrics.js";
+import { kmhToMph, kmToMi, mToFt } from "./units.js";
 
 /**
  * Narrative module — composes a `!post` event into a structured blog post via
@@ -252,6 +253,7 @@ const SYSTEM_PROMPT_TRACK = [
   '- "title": ≤60 characters, evocative, anchored to place + activity. No clickbait, no emoji.',
   '- "haiku": exactly three lines separated by newlines, in 5/7/5 syllables, ≤110 characters total. Plain English, observational.',
   '- "body": ≤3000 characters. Describe the route, place, conditions, and pace. Use long stops as paragraph breaks. Do not invent companions, motivations, or destinations not present in the metrics or place names.',
+  "- Use US customary units exclusively in the body: miles, feet, °F, mph. Never kilometers, meters, °C, or km/h. The numbers in the input are already imperial — render them in the body using the same units shown.",
 ].join("\n");
 
 /**
@@ -325,11 +327,11 @@ function buildTrackPrompt(input: TrackNarrativeInput): string {
   const m = input.metrics;
   const lines: string[] = [];
   lines.push("Tracking session metrics:");
-  lines.push(`- Distance: ${m.distanceKm.toFixed(2)} km`);
+  lines.push(`- Distance: ${kmToMi(m.distanceKm).toFixed(2)} mi`);
   lines.push(`- Duration: ${(m.durationSeconds / 60).toFixed(0)} minutes`);
-  lines.push(`- Elevation gain: ${m.elevation.gainM.toFixed(0)} m`);
+  lines.push(`- Elevation gain: ${mToFt(m.elevation.gainM).toFixed(0)} ft`);
   lines.push(`- Activity: ${m.activityHint}, route shape: ${m.routeShape}`);
-  lines.push(`- Average speed: ${m.pace.avgKmh.toFixed(1)} km/h, p95: ${m.pace.p95Kmh.toFixed(1)} km/h`);
+  lines.push(`- Average speed: ${kmhToMph(m.pace.avgKmh).toFixed(1)} mph, p95: ${kmhToMph(m.pace.p95Kmh).toFixed(1)} mph`);
   if (input.startPlace) lines.push(`Start: ${input.startPlace}`);
   if (input.endPlace) lines.push(`End: ${input.endPlace}`);
   if (input.midpointPlace) lines.push(`Midpoint: ${input.midpointPlace}`);

--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -12,6 +12,7 @@ import { recordTransaction } from "./ledger.js";
 import { log } from "../adapters/logging/worker-logs.js";
 import { reverseGeocode } from "../adapters/location/geocode.js";
 import { currentWeather } from "../adapters/location/weather.js";
+import { kmToMi, mToFt } from "./units.js";
 
 const TRACK_RECORD_TTL_SECONDS = 60 * 60 * 24 * 365;
 const TRACK_START_TTL_SECONDS = 60 * 60 * 24;
@@ -225,12 +226,12 @@ export async function handleStopTrack(
 }
 
 function formatTrackReply(metrics: TrackMetrics, url: string): string {
-  const km = metrics.distanceKm.toFixed(1);
-  const gainM = Math.round(metrics.elevation.gainM);
+  const mi = kmToMi(metrics.distanceKm).toFixed(1);
+  const gainFt = Math.round(mToFt(metrics.elevation.gainM));
   const minutes = Math.round(metrics.durationSeconds / 60);
   const duration =
     minutes >= 60
       ? `${Math.floor(minutes / 60)}h${minutes % 60}m`
       : `${minutes}min`;
-  return `Track posted: ${km}km, ${gainM}m gain, ${duration}\n${url}`;
+  return `Track posted: ${mi}mi, ${gainFt}ft gain, ${duration}\n${url}`;
 }

--- a/src/core/units.ts
+++ b/src/core/units.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit conversion helpers. Internal source-of-truth in TrackMetrics and KV
+ * records stays canonical metric (haversine math is naturally km/m); these
+ * convert at the user-facing display layer — SMS reply, journal frontmatter,
+ * LLM prompt input. See #195 for the operator-preference rationale.
+ *
+ * Weather is already imperial at the source (`adapters/location/weather.ts`
+ * passes `temperature_unit=fahrenheit&wind_speed_unit=mph` to Open-Meteo).
+ */
+
+const KM_PER_MI = 1.609344;
+const M_PER_FT = 0.3048;
+
+export function kmToMi(km: number): number {
+  return km / KM_PER_MI;
+}
+
+export function mToFt(m: number): number {
+  return m / M_PER_FT;
+}
+
+export function kmhToMph(kmh: number): number {
+  return kmh / KM_PER_MI;
+}
+
+/**
+ * Convert a multi-line haiku (lines separated by `\n`) into CommonMark with
+ * soft-breaks — two trailing spaces before each newline — so the published
+ * HTML renders three visually distinct lines instead of collapsing into a
+ * single paragraph. The final line gets no trailing spaces.
+ */
+export function formatHaiku(haiku: string): string {
+  const lines = haiku.split("\n");
+  if (lines.length <= 1) return haiku;
+  const head = lines.slice(0, -1).map((l) => `${l}  `);
+  return [...head, lines[lines.length - 1]].join("\n");
+}

--- a/tests/github-pages.test.ts
+++ b/tests/github-pages.test.ts
@@ -165,7 +165,10 @@ describe("publishPost — happy path", () => {
     expect(decoded).toContain("location: { lat: 37.1682, lon: -118.5891, place: \"Lake Sabrina\" }");
     expect(decoded).toContain('weather: "Clear · 8C"');
     expect(decoded).toContain("tags: [trailscribe]");
-    expect(decoded).toContain("Granite glow\nCold cirque wind\nDay turns");
+    // Haiku rendered with CommonMark soft-breaks (two trailing spaces) so the
+    // three lines survive into the published HTML instead of collapsing into a
+    // single paragraph. See #195.
+    expect(decoded).toContain("Granite glow  \nCold cirque wind  \nDay turns");
     expect(decoded).toContain("Pink light bleeds.");
   });
 });

--- a/tests/narrative.test.ts
+++ b/tests/narrative.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { generateNarrative, NarrativeError } from "../src/core/narrative.js";
+import { generateNarrative, generateTrackNarrative, NarrativeError } from "../src/core/narrative.js";
 import type { Env } from "../src/env.js";
 import { makeTestEnv } from "./helpers/env.js";
 
@@ -330,5 +330,51 @@ describe("LLM_PROVIDER_HEADERS_JSON — analytics passthrough", () => {
 
     const out = await generateNarrative({ note: "x", env });
     expect(out.title).toBe("T");
+  });
+});
+
+describe("generateTrackNarrative — imperial units in LLM input (#195)", () => {
+  test("buildTrackPrompt sends mi/ft/mph; system prompt instructs US customary", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ title: "T", haiku: "a\nb\nc", body: "B" }),
+    );
+
+    await generateTrackNarrative({
+      metrics: {
+        pingCount: 14,
+        startedAt: Date.parse("2026-05-02T15:51:30Z"),
+        closedAt: Date.parse("2026-05-02T16:24:30Z"),
+        durationSeconds: 1980,
+        distanceKm: 10,
+        pace: { avgKmh: 16, p50Kmh: 15, p95Kmh: 20 },
+        elevation: { gainM: 100, lossM: 80, minM: 0, maxM: 100 },
+        routeShape: "out-and-back",
+        activityHint: "bike",
+      },
+      startPlace: "Malibu, CA",
+      endPlace: "Topanga, CA",
+      env,
+    });
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const userMsg = body.messages.find((m) => m.role === "user")?.content ?? "";
+    const sysMsg = body.messages.find((m) => m.role === "system")?.content ?? "";
+
+    // No metric units leak through to the model.
+    expect(userMsg).not.toMatch(/\bkm\b/);
+    expect(userMsg).not.toMatch(/\bkm\/h\b/);
+    expect(userMsg).not.toMatch(/\bmeters?\b/);
+
+    // Imperial values present: 10 km → 6.21 mi; 100 m → 328 ft; 16 km/h → 9.94 mph.
+    expect(userMsg).toMatch(/Distance: 6\.21 mi/);
+    expect(userMsg).toMatch(/Elevation gain: 328 ft/);
+    expect(userMsg).toMatch(/Average speed: 9\.9 mph/);
+    expect(userMsg).toMatch(/p95: 12\.4 mph/);
+
+    // System prompt explicitly instructs imperial in the body.
+    expect(sysMsg).toMatch(/US customary units|miles, feet|mph/);
   });
 });

--- a/tests/tracking.test.ts
+++ b/tests/tracking.test.ts
@@ -201,10 +201,15 @@ describe("publishTrackPost", () => {
     const body = JSON.parse((putCall[1]?.body ?? "{}") as string);
     const decoded = atob(body.content);
     expect(decoded).toContain("type: track");
-    expect(decoded).toContain("distance_km: 2.5");
+    // 2.5 km → 1.55 mi (kmToMi(2.5) = 1.5534...); 35 m → 115 ft (mToFt(35) = 114.83...).
+    // See #195 — frontmatter renamed to imperial.
+    expect(decoded).toContain("distance_mi: 1.55");
+    expect(decoded).toContain("elevation_gain_ft: 115");
     expect(decoded).toContain("route_shape: out-and-back");
     expect(decoded).toContain("start_place: \"Malibu, CA\"");
     expect(decoded).toContain("end_place: \"Malibu, CA\"");
+    // Haiku rendered with CommonMark soft-breaks (#195).
+    expect(decoded).toContain("a  \nb  \nc");
   });
 });
 

--- a/tests/units.test.ts
+++ b/tests/units.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import { formatHaiku, kmhToMph, kmToMi, mToFt } from "../src/core/units.js";
+
+describe("units — metric → imperial conversions", () => {
+  test("kmToMi: 1 km is ~0.621371 mi", () => {
+    expect(kmToMi(1)).toBeCloseTo(0.621371, 6);
+  });
+
+  test("kmToMi: 611.984 km (Pinal→Redlands fixture) ≈ 380.27 mi", () => {
+    expect(kmToMi(611.984)).toBeCloseTo(380.27, 2);
+  });
+
+  test("kmToMi: 0 → 0", () => {
+    expect(kmToMi(0)).toBe(0);
+  });
+
+  test("mToFt: 1 m is ~3.28084 ft", () => {
+    expect(mToFt(1)).toBeCloseTo(3.28084, 5);
+  });
+
+  test("mToFt: 2336.35 m (Pinal→Redlands fixture) ≈ 7665 ft", () => {
+    expect(Math.round(mToFt(2336.35))).toBe(7665);
+  });
+
+  test("kmhToMph: 100 km/h ≈ 62.14 mph", () => {
+    expect(kmhToMph(100)).toBeCloseTo(62.1371, 4);
+  });
+});
+
+describe("formatHaiku — single-string → CommonMark soft-break-separated lines", () => {
+  test("three-line haiku gets two-trailing-spaces between lines", () => {
+    expect(formatHaiku("First line\nSecond line\nThird line")).toBe(
+      "First line  \nSecond line  \nThird line",
+    );
+  });
+
+  test("preserves leading/trailing whitespace within each line", () => {
+    expect(formatHaiku("a\n b \nc")).toBe("a  \n b   \nc");
+  });
+
+  test("single line (degenerate) returns unchanged", () => {
+    expect(formatHaiku("just one")).toBe("just one");
+  });
+
+  test("empty string returns empty", () => {
+    expect(formatHaiku("")).toBe("");
+  });
+
+  test("does not append two spaces to the final line (would be a trailing-whitespace lint issue in some configs)", () => {
+    const out = formatHaiku("a\nb\nc");
+    expect(out.endsWith("c")).toBe(true);
+    expect(out.endsWith("  ")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #195.

## Summary
- **Imperial units everywhere** for track surfaces — SMS reply, journal frontmatter, LLM prompt input + system prompt instruction. Converted at the display layer via a new `src/core/units.ts` helper; `TrackMetrics` and TS_TRACKS KV records stay canonical-metric (haversine math is naturally km/m, and renaming the source-of-truth would force fixture + KV migration for no behavioral gain).
- **Haiku rendered as 3 visually distinct lines** in published HTML via CommonMark soft-breaks (two trailing spaces). Applied to all three publish render functions (`renderMarkdown`, `renderMarkdownWithImage`, `renderTrackMarkdown`) — covers `!post`, `!postimg`, and track posts.
- **Weather untouched** — already imperial via Open-Meteo adapter (`temperature_unit=fahrenheit&wind_speed_unit=mph` at `src/adapters/location/weather.ts:41`).

### Sample new track SMS (from #175's Pinal→Redlands fixture)
```
Track posted: 380.3mi, 7665ft gain, 8h37m
https://brockamer.github.io/trailscribe-journal/2026/05/17/pinal-county-to-redlands-high-desert-transit.html
```
143 chars — well inside the 320-char reply budget.

### Sample new track frontmatter
```yaml
track:
  duration_seconds: 31020
  distance_mi: 380.27
  elevation_gain_ft: 7665
  activity_hint: drive
  route_shape: point-to-point
```

### Sample published HTML
Was (one paragraph):
> Hot asphalt unwinds Saguaro gives way to sage dust settles at dusk

Now (three lines via `<br>` soft-breaks):
> Hot asphalt unwinds  
> Saguaro gives way to sage  
> dust settles at dusk

## Test plan
- [x] 11 new unit tests in `tests/units.test.ts` cover `kmToMi`, `mToFt`, `kmhToMph`, `formatHaiku`.
- [x] 1 new test in `tests/narrative.test.ts` asserts `generateTrackNarrative` sends mi/ft/mph (and not km/m/km/h) to the LLM, and that the system prompt instructs US customary units.
- [x] Existing `tests/github-pages.test.ts` haiku assertion updated for the new soft-break convention.
- [x] Existing `tests/tracking.test.ts` track-frontmatter assertion updated for renamed `distance_mi` / `elevation_gain_ft` keys + new haiku rendering.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` — **407/407 passing across 36 files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)