### PR TITLE
fix(tracking): refuse to publish single-ping sessions (#197)

### DIFF
--- a/src/core/tracking.ts
+++ b/src/core/tracking.ts
@@ -149,6 +149,34 @@ export async function handleStopTrack(
       return { skipped: "no_pings" };
     }
 
+    // Single-ping session: there is no segment to summarise. Distance is
+    // mathematically zero (Haversine needs two points), duration collapses
+    // (startedAt == closedAt from the one ping's timestamp), and `paceStats`
+    // would return the single ping's velocity as the avg / p50 / p95 — all
+    // technically true, but enough to drive an LLM toward a "session"
+    // narrative built around a single moment. We refuse to publish.
+    //
+    // Root cause is upstream: Mini 3 Plus auto-extends the tracking interval
+    // when it detects no motion (we've observed mc=11 events with
+    // status.intervalChange=14400, i.e. 4-hour interval), so a short session
+    // can leave MapShare with one ingested breadcrumb (or zero) by the time
+    // mc 12 arrives.
+    if (pings.length === 1) {
+      log({
+        event: "track_too_brief",
+        level: "warn",
+        imei: event.imei,
+        idemKey,
+        pingCount: 1,
+      });
+      await sendReply(
+        event.imei,
+        ["Track too brief — 1 breadcrumb. Try longer or move sooner after Start."],
+        env,
+      );
+      return { skipped: "too_brief" };
+    }
+
     const metrics = computeMetrics(pings);
     const startPing = pings[0];
     const endPing = pings[pings.length - 1];

--- a/tests/tracking.test.ts
+++ b/tests/tracking.test.ts
@@ -396,6 +396,48 @@ describe("handleStopTrack — end to end", () => {
     expect(vi.mocked(sendReply).mock.calls[0][1][0]).toContain("no breadcrumbs");
   });
 
+  test("single-ping KML: sends 'too brief' reply, no publish, no narrative (#197)", async () => {
+    const env = makeTestEnv();
+    const closedAt = Date.now();
+    await seedSessionStart(env, "300052030374220", closedAt - 5 * 60 * 1000);
+
+    // Minimal one-Placemark KML — mirrors the Garmin MapShare share-page shape
+    // that produced the ghost-post bug (Session 1 on 2026-05-17: pingCount=1,
+    // distance=0, but a real per-ping velocity that flowed through to the LLM
+    // as a defensible-but-meaningless "drive at 65.6 mph" narrative).
+    const singlePingKml = `<?xml version="1.0"?>
+<kml><Document><Placemark>
+  <TimeStamp><when>2026-05-18T03:09:30Z</when></TimeStamp>
+  <ExtendedData>
+    <Data name="Latitude"><value>34.02767</value></Data>
+    <Data name="Longitude"><value>-118.75931</value></Data>
+    <Data name="Elevation"><value>40.92 m</value></Data>
+    <Data name="Velocity"><value>65.5 km/h</value></Data>
+    <Data name="Course"><value>247.5</value></Data>
+    <Data name="Valid GPS Fix"><value>True</value></Data>
+  </ExtendedData>
+</Placemark></Document></kml>`;
+
+    vi.spyOn(mapshareMod, "fetchMapShareKml").mockResolvedValue(singlePingKml);
+    const publishSpy = vi.spyOn(publishMod, "publishTrackPost");
+    const narrativeSpy = vi.spyOn(narrativeMod, "generateTrackNarrative");
+
+    await handleStopTrack(
+      { imei: "300052030374220", messageCode: 12, timeStamp: closedAt },
+      env,
+      "idem-key-too-brief",
+    );
+
+    expect(narrativeSpy).not.toHaveBeenCalled();
+    expect(publishSpy).not.toHaveBeenCalled();
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    const reply = vi.mocked(sendReply).mock.calls[0][1][0];
+    expect(reply).toContain("Track too brief");
+    expect(reply).toContain("1 breadcrumb");
+    // Reply must fit Garmin's 160-char Iridium limit
+    expect(reply.length).toBeLessThanOrEqual(160);
+  });
+
   test("inner-LLM checkpoint: narrative cached when publish fails, re-run avoids fresh LLM call (#172)", async () => {
     const env = makeTestEnv();
     await seedSessionStart(env, "300052030374220", Date.parse("2026-05-02T15:51:30Z"));


### PR DESCRIPTION
## Summary
- Closes #197 (with a corrected diagnosis — see below).
- `handleStopTrack` now refuses to publish when MapShare returns `pings.length < 2`, mirroring the existing 0-ping branch but with distinct logging (`track_too_brief`) and a distinct SMS reply: *"Track too brief — 1 breadcrumb. Try longer or move sooner after Start."* (71 chars, under the 160-char Iridium cap).
- Adds a single-ping regression test in `tests/tracking.test.ts`.

## Corrected diagnosis (the LLM was not hallucinating)

The original issue framed the 65.6 mph speed reading in the ghost San Dimas post as an LLM hallucination. Live tracing on 2026-05-17 disproved that:

- `paceStats()` (track-metrics.ts:93-102) short-circuits on length-1 inputs via `percentile()` (lines 105-111): `percentile([65.6], _) → 65.6`. So `computeMetrics([singlePing])` returns `{avg: 65.6, p50: 65.6, p95: 65.6}` — all *real*, all from the one ping's per-point `velocityKmh`.
- `buildTrackPrompt()` (narrative.ts:326-340) faithfully renders those values. The LLM received true data and reported it.
- The title *"San Dimas to San Dimas: A Drive Going Nowhere"* was a defensible read of `0 mi / 0 min / drive activity / 65.6 mph p95`, not invention.

So the fix is not anti-hallucination — it's "don't publish a session narrative for what was effectively a single GPS snapshot."

## Live test that confirmed the root cause

Real-device test 2026-05-17 03:09:30Z → 03:27:15Z (17m45s) on Pacific Coast Highway, captured via `wrangler tail` against production:

| device time | mc | `intervalChange` | speed | event |
|---|---|---|---|---|
| 03:09:30 | 10 Start | 120 (2 min) | 41 mph | Session opens, interval = device setting ✓ |
| 03:11:30 | 0 ping | 0 | 0 mph | Ping at 2-min mark, vehicle stopped |
| 03:13:30 | 11 | **14400 (4 hr)** | 0 mph | **Device autonomously moves to 4-hr interval (stationary detection)** |
| 03:23:30 | 11 | 120 (2 min) | 39 mph | Device reverts when motion resumes |
| 03:25:30 | 0 ping | 0 | 50 mph | Normal 2-min ping |
| 03:27:15 | 12 Stop | 0 | 47 mph | Session closes |

Mini 3 Plus auto-extends the tracking interval to 4 hours when it detects no motion. For prior sessions:
- **Session 1** (brief drive, ghost post): only the start-time ping landed in MapShare before the device went into 4-hr mode → single ping → published anyway → bug.
- **Session 2** (8-min, no publish): zero pings landed before Stop → existing `track_no_pings` branch handled it correctly.

The published test post (`2026-05-18-coast-road-drive-malibu-to-malibu.md`) captured 6 MapShare pings, 4.10 mi, real metrics — confirming MapShare and IPC Outbound are separate ingest streams (IPC saw 2 mc=0 events; MapShare's KML had 6 pings).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 408/408 passing, including new single-ping regression
- [ ] Real-device verification post-merge: trigger a sub-2-min track in a parking lot and confirm the new "Track too brief" SMS instead of a published ghost post
- [ ] Ghost-post fate (Session 1's *"A Drive Going Nowhere"*) — operator's call, tracked in #197

## Out of scope (filed separately)
- Permanent enable of `LOG_TRACK_PAYLOADS=true` — investigation showed the diagnostic flag earned its keep by exposing `status.intervalChange`. Follow-up PR.
- `SYSTEM_PROMPT_TRACK` "no invention" tightening — original issue's optional ask; investigation showed it's unnecessary (no actual invention occurred).
- `buildTrackPrompt` line-suppression when distance=0 — same reason: unreachable with the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)