### PR TITLE
chore(observability): enable LOG_TRACK_PAYLOADS by default in all envs (#199)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,11 +28,13 @@ DAILY_TOKEN_BUDGET = "50000"
 IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
 IPC_INBOUND_DRY_RUN = "false"
-# Diagnostic: when "true", log full payload of non-Free-Text events (tracking
-# pings, Start/Stop Track, etc.) so a fixture can be reconstructed from logs
-# during a real device session. Default off — the silent-drop policy still
-# applies; this just changes what the drop log line carries.
-LOG_TRACK_PAYLOADS = "false"
+# Log full payload of non-Free-Text events (tracking pings, Start/Stop Track,
+# interval changes, etc.) so a fixture can be reconstructed from logs during a
+# real device session. The silent-drop policy still applies; this just changes
+# what the drop log line carries. Defaulted on per #199 after #197 investigation
+# proved the per-event payload (~300 bytes) is what surfaces device behavior
+# like `status.intervalChange` flapping mid-session.
+LOG_TRACK_PAYLOADS = "true"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
@@ -113,7 +115,7 @@ IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
 # delivering real SMS to the operator's device. Production deploys are
 # blocked from setting this — see src/env.ts parseEnv guard.
 IPC_INBOUND_DRY_RUN = "false"
-LOG_TRACK_PAYLOADS = "false"
+LOG_TRACK_PAYLOADS = "true"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe (staging)"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"
@@ -169,7 +171,7 @@ IPC_SCHEMA_VERSION = "2"
 IPC_INBOUND_SENDER = "trailscribe@tx.trailscribe.net"
 # Production must always deliver. parseEnv throws if this is "true" + env=production.
 IPC_INBOUND_DRY_RUN = "false"
-LOG_TRACK_PAYLOADS = "false"
+LOG_TRACK_PAYLOADS = "true"
 RESEND_FROM_EMAIL = "trailscribe@tx.trailscribe.net"
 RESEND_FROM_NAME = "TrailScribe"
 JOURNAL_POST_PATH_TEMPLATE = "_posts/{yyyy}-{mm}-{dd}-{slug}.md"


### PR DESCRIPTION
## Summary
- Closes #199.
- Flips `LOG_TRACK_PAYLOADS` from `"false"` to `"true"` in all three `wrangler.toml` blocks (`[vars]`, `[env.staging.vars]`, `[env.production.vars]`).
- Updates the inline comment to explain the new default and link the rationale.

## Why now

During #197 investigation (PR #198), real-device tracing surfaced that the Mini 3 Plus autonomously flaps its tracking interval between 120s and 14400s based on stationary detection. The `status.intervalChange` field that revealed this only became visible because `LOG_TRACK_PAYLOADS=true` was already on at the time the test ran.

The original "default off, flip on for specific investigations" assumption is backwards: the cost is negligible (~300 bytes per non-Free-Text event, and the silent-drop policy already constrains those to tracking events only) and the value materialises only when something unexpected happens. By the time you realise you need the payload, the event is gone.

## What did NOT change
- Code gate in `src/env.ts` (`shouldLogTrackPayloads`) and `src/app.ts` (line 225) — toggle still works the same way
- Test helper `tests/helpers/env.ts` — still defaults to `"false"`, so the existing "default behavior" tests in `tests/app.test.ts:290-302` continue to assert the off-path correctly

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 407/407 passing
- [ ] Post-merge: verify a production tracking event (or the next `!ping`) shows the full payload in `non_free_text` log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)