### PR TITLE
refactor(narrative,publish): extract shared helpers across post/track variants (#174)

### DIFF
--- a/src/adapters/publish/github-pages.ts
+++ b/src/adapters/publish/github-pages.ts
@@ -44,6 +44,70 @@ interface ContentsApiErrorBody {
   message?: string;
 }
 
+interface ResolvedPublishPath {
+  yyyy: string;
+  mm: string;
+  dd: string;
+  slug: string;
+  path: string;
+  url: string;
+}
+
+/**
+ * Derive the dated path + slug + public URL for a post. Shared across all
+ * three publish callers (publishPost, publishTrackPost, publishPostWithImage)
+ * — they differ in render shape and commit mechanism, but the slug-and-path
+ * derivation is identical.
+ *
+ * The caller resolves `now` (request time for !post / postimg; closedAt for
+ * track) before calling. Keeps this helper pure.
+ */
+async function resolvePublishPath(args: {
+  env: Env;
+  title: string;
+  now: Date;
+}): Promise<ResolvedPublishPath> {
+  const yyyy = String(args.now.getUTCFullYear());
+  const mm = pad2(args.now.getUTCMonth() + 1);
+  const dd = pad2(args.now.getUTCDate());
+
+  const baseSlug = slugify(args.title, args.now);
+  const { path, slug } = await findFreePath(args.env, args.env.JOURNAL_POST_PATH_TEMPLATE, {
+    yyyy,
+    mm,
+    dd,
+    baseSlug,
+  });
+
+  const url = renderUrl(args.env.JOURNAL_URL_TEMPLATE, { yyyy, mm, dd, slug });
+  return { yyyy, mm, dd, slug, path, url };
+}
+
+/**
+ * Contents-API PUT publish path shared by `publishPost` and `publishTrackPost`.
+ * Resolves the path, calls `renderFn` to produce the markdown (variant-specific
+ * frontmatter), commits via Contents API PUT (with retry on 5xx).
+ *
+ * `publishPostWithImage` uses a different commit mechanism (atomic GraphQL
+ * `createCommitOnBranch`) and shares only `resolvePublishPath`.
+ *
+ * Auth: fine-grained PAT in `GITHUB_JOURNAL_TOKEN` scoped to exactly the
+ * journal repo (`contents:write`). 4xx surfaces immediately (auth/perm bug —
+ * retrying won't help). 5xx retries 1 s / 4 s / 16 s.
+ */
+async function publishMarkdown(args: {
+  env: Env;
+  title: string;
+  now: Date;
+  delay: (ms: number) => Promise<void>;
+  renderFn: (resolved: ResolvedPublishPath) => string;
+}): Promise<PublishPostResult> {
+  const resolved = await resolvePublishPath({ env: args.env, title: args.title, now: args.now });
+  const markdown = args.renderFn(resolved);
+  const putResp = await putContents(args.env, resolved.path, markdown, args.title, args.delay);
+  return { url: resolved.url, path: resolved.path, sha: putResp.commit.sha };
+}
+
 /**
  * Commit one markdown file per `!post` to the dedicated journal repo via the
  * GitHub Contents API. Public URL is derived from `JOURNAL_URL_TEMPLATE`
@@ -53,10 +117,6 @@ interface ContentsApiErrorBody {
  * plus hyphens, ≤ 50 chars). On the rare same-minute collision we GET the
  * candidate path; on 200 we increment a `-2`, `-3`, … suffix until 404.
  *
- * Auth: fine-grained PAT in `GITHUB_JOURNAL_TOKEN` scoped to exactly the
- * journal repo (`contents:write`). 4xx surfaces immediately (auth/perm bug
- * — retrying won't help). 5xx retries 1 s / 4 s / 16 s.
- *
  * Frontmatter shape (Jekyll/Hugo compatible). `location:` and `weather:`
  * keys are omitted when their inputs are absent — no `(0, 0)` placeholders.
  */
@@ -65,33 +125,23 @@ export async function publishPost(args: PublishPostArgs): Promise<PublishPostRes
   const now = (args.now ?? (() => new Date()))();
   const delay = args.delay ?? defaultDelay;
 
-  const yyyy = String(now.getUTCFullYear());
-  const mm = pad2(now.getUTCMonth() + 1);
-  const dd = pad2(now.getUTCDate());
-
-  const baseSlug = slugify(title, now);
-  const { path, slug: finalSlug } = await findFreePath(env, args.env.JOURNAL_POST_PATH_TEMPLATE, {
-    yyyy,
-    mm,
-    dd,
-    baseSlug,
-  });
-
-  const markdown = renderMarkdown({
+  return publishMarkdown({
+    env,
     title,
-    haiku,
-    body,
-    date: now.toISOString(),
-    lat,
-    lon,
-    placeName,
-    weather,
+    now,
+    delay,
+    renderFn: () =>
+      renderMarkdown({
+        title,
+        haiku,
+        body,
+        date: now.toISOString(),
+        lat,
+        lon,
+        placeName,
+        weather,
+      }),
   });
-
-  const putResp = await putContents(env, path, markdown, title, delay);
-
-  const url = renderUrl(env.JOURNAL_URL_TEMPLATE, { yyyy, mm, dd, slug: finalSlug });
-  return { url, path, sha: putResp.commit.sha };
 }
 
 /**
@@ -321,24 +371,14 @@ export async function publishPostWithImage(
   const { title, haiku, body, lat, lon, placeName, weather, env, image } = args;
   const now = (args.now ?? (() => new Date()))();
 
-  const yyyy = String(now.getUTCFullYear());
-  const mm = pad2(now.getUTCMonth() + 1);
-  const dd = pad2(now.getUTCDate());
-
-  const baseSlug = slugify(title, now);
-  const { path, slug: finalSlug } = await findFreePath(env, env.JOURNAL_POST_PATH_TEMPLATE, {
-    yyyy,
-    mm,
-    dd,
-    baseSlug,
-  });
+  const resolved = await resolvePublishPath({ env, title, now });
 
   const ext = extensionForMime(image.mimeType);
   const imagePath = image.pathTemplate
-    .replaceAll("{yyyy}", yyyy)
-    .replaceAll("{mm}", mm)
-    .replaceAll("{dd}", dd)
-    .replaceAll("{slug}", finalSlug)
+    .replaceAll("{yyyy}", resolved.yyyy)
+    .replaceAll("{mm}", resolved.mm)
+    .replaceAll("{dd}", resolved.dd)
+    .replaceAll("{slug}", resolved.slug)
     .replaceAll("{ext}", ext);
 
   const markdown = renderMarkdownWithImage({
@@ -366,7 +406,7 @@ export async function publishPostWithImage(
       expectedHeadOid,
       fileChanges: {
         additions: [
-          { path, contents: base64Utf8(markdown) },
+          { path: resolved.path, contents: base64Utf8(markdown) },
           { path: imagePath, contents: base64Bytes(image.bytes) },
         ],
       },
@@ -408,10 +448,9 @@ export async function publishPostWithImage(
     });
   }
 
-  const url = renderUrl(env.JOURNAL_URL_TEMPLATE, { yyyy, mm, dd, slug: finalSlug });
   return {
-    url,
-    path,
+    url: resolved.url,
+    path: resolved.path,
     sha: commit.oid,
     imagePath,
     commitOid: commit.oid,
@@ -545,33 +584,24 @@ export async function publishTrackPost(args: PublishTrackPostArgs): Promise<Publ
   const now = (args.now ?? (() => new Date(metrics.closedAt)))();
   const delay = args.delay ?? defaultDelay;
 
-  const yyyy = String(now.getUTCFullYear());
-  const mm = pad2(now.getUTCMonth() + 1);
-  const dd = pad2(now.getUTCDate());
-
-  const baseSlug = slugify(title, now);
-  const { path, slug: finalSlug } = await findFreePath(env, env.JOURNAL_POST_PATH_TEMPLATE, {
-    yyyy,
-    mm,
-    dd,
-    baseSlug,
-  });
-
-  const markdown = renderTrackMarkdown({
+  return publishMarkdown({
+    env,
     title,
-    haiku,
-    body,
-    metrics,
-    endLat,
-    endLon,
-    startPlace,
-    endPlace,
-    weather,
+    now,
+    delay,
+    renderFn: () =>
+      renderTrackMarkdown({
+        title,
+        haiku,
+        body,
+        metrics,
+        endLat,
+        endLon,
+        startPlace,
+        endPlace,
+        weather,
+      }),
   });
-
-  const putResp = await putContents(env, path, markdown, title, delay);
-  const url = renderUrl(env.JOURNAL_URL_TEMPLATE, { yyyy, mm, dd, slug: finalSlug });
-  return { url, path, sha: putResp.commit.sha };
 }
 
 function renderTrackMarkdown(a: {

--- a/src/core/narrative.ts
+++ b/src/core/narrative.ts
@@ -47,7 +47,7 @@ export interface NarrativeOutput {
 }
 
 /** JSON-schema enforced by the LLM provider's structured-output mode. */
-const NARRATIVE_SCHEMA = {
+const POST_NARRATIVE_SCHEMA = {
   name: "narrative",
   strict: true,
   schema: {
@@ -62,7 +62,7 @@ const NARRATIVE_SCHEMA = {
   },
 } as const;
 
-const NarrativeContentSchema = z.object({
+const PostContentSchema = z.object({
   title: z.string().min(1).max(60),
   haiku: z.string().min(1).max(110),
   body: z.string().min(1).max(500),
@@ -73,7 +73,7 @@ const NarrativeContentSchema = z.object({
  * length caps server-side; the prompt is what makes the model actually *try*
  * to stay within them and to match the user's voice.
  */
-const SYSTEM_PROMPT_WITH_NOTE = [
+const SYSTEM_PROMPT_POST_WITH_NOTE = [
   "You write short field-journal entries from a backcountry traveller's brief notes.",
   "Always return valid JSON matching the schema. No prose outside the JSON.",
   "Constraints:",
@@ -90,7 +90,7 @@ const SYSTEM_PROMPT_WITH_NOTE = [
  * specifics not present in the metadata — a stronger constraint than the
  * with-note prompt because there's no anchoring caption to ground it.
  */
-const SYSTEM_PROMPT_NO_NOTE = [
+const SYSTEM_PROMPT_POST_NO_NOTE = [
   "You write short field-journal entries from a backcountry traveller's location and weather snapshot. The traveller did not provide a caption — describe what is true about this position and moment, in observational third-person, from the metadata alone.",
   "Always return valid JSON matching the schema. No prose outside the JSON.",
   "Constraints:",
@@ -106,26 +106,40 @@ export class NarrativeError extends Error {
   }
 }
 
-export async function generateNarrative(input: NarrativeInput): Promise<NarrativeOutput> {
-  const userPrompt = buildUserPrompt(input);
-  const model = input.env.LLM_MODEL || "anthropic/claude-sonnet-4-6";
-  const systemPrompt =
-    input.note !== undefined && input.note.trim().length > 0
-      ? SYSTEM_PROMPT_WITH_NOTE
-      : SYSTEM_PROMPT_NO_NOTE;
+interface RunNarrativeCallOpts<T> {
+  env: Env;
+  model: string;
+  systemPrompt: string;
+  userPrompt: string;
+  responseSchema: { name: string; strict: true; schema: object };
+  zodSchema: z.ZodType<T>;
+  maxTokens: number;
+  diagKind: "post" | "track";
+}
 
+/**
+ * Shared OpenRouter call + response handling for both `!post` and tracking
+ * narrative variants. Owns: chatCompletion invocation, missing-content
+ * diagnostics, JSON.parse error wrapping, zod validation, usage extraction.
+ *
+ * Callers supply variant-specific prompts, schemas, and `diagKind` literal so
+ * a failed call can be traced back to the originating pipeline in logs.
+ */
+async function runNarrativeCall<T>(
+  opts: RunNarrativeCallOpts<T>,
+): Promise<{ data: T; usage: NarrativeOutput["usage"] }> {
   const response = await chatCompletion({
     req: {
-      model,
+      model: opts.model,
       messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
+        { role: "system", content: opts.systemPrompt },
+        { role: "user", content: opts.userPrompt },
       ],
-      response_format: { type: "json_schema", json_schema: NARRATIVE_SCHEMA },
+      response_format: { type: "json_schema", json_schema: opts.responseSchema },
       temperature: 0.7,
-      max_tokens: 600,
+      max_tokens: opts.maxTokens,
     },
-    env: input.env,
+    env: opts.env,
   });
 
   const content = response.choices[0]?.message?.content;
@@ -135,8 +149,8 @@ export async function generateNarrative(input: NarrativeInput): Promise<Narrativ
       event: "narrative_diag",
       level: "warn",
       diag: {
-        kind: "post",
-        model,
+        kind: opts.diagKind,
+        model: opts.model,
         choicesLen: response.choices.length,
         finishReason: choice0?.finish_reason ?? null,
         messageKeys: choice0?.message ? Object.keys(choice0.message) : [],
@@ -146,7 +160,11 @@ export async function generateNarrative(input: NarrativeInput): Promise<Narrativ
         usage: response.usage ?? null,
       },
     });
-    throw new NarrativeError("LLM returned no content");
+    throw new NarrativeError(
+      opts.diagKind === "track"
+        ? "LLM returned no content for track narrative"
+        : "LLM returned no content",
+    );
   }
 
   let parsed: unknown;
@@ -158,21 +176,44 @@ export async function generateNarrative(input: NarrativeInput): Promise<Narrativ
     });
   }
 
-  const validated = NarrativeContentSchema.safeParse(parsed);
+  const validated = opts.zodSchema.safeParse(parsed);
   if (!validated.success) {
     const issues = validated.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
-    throw new NarrativeError(`LLM output failed schema: ${issues}`);
+    throw new NarrativeError(
+      opts.diagKind === "track"
+        ? `Track narrative failed schema: ${issues}`
+        : `LLM output failed schema: ${issues}`,
+    );
   }
 
   return {
-    title: validated.data.title,
-    haiku: validated.data.haiku,
-    body: validated.data.body,
+    data: validated.data,
     usage: {
       prompt_tokens: response.usage.prompt_tokens,
       completion_tokens: response.usage.completion_tokens,
     },
   };
+}
+
+export async function generateNarrative(input: NarrativeInput): Promise<NarrativeOutput> {
+  const userPrompt = buildUserPrompt(input);
+  const systemPrompt =
+    input.note !== undefined && input.note.trim().length > 0
+      ? SYSTEM_PROMPT_POST_WITH_NOTE
+      : SYSTEM_PROMPT_POST_NO_NOTE;
+
+  const { data, usage } = await runNarrativeCall({
+    env: input.env,
+    model: input.env.LLM_MODEL || "anthropic/claude-sonnet-4-6",
+    systemPrompt,
+    userPrompt,
+    responseSchema: POST_NARRATIVE_SCHEMA,
+    zodSchema: PostContentSchema,
+    maxTokens: 600,
+    diagKind: "post",
+  });
+
+  return { title: data.title, haiku: data.haiku, body: data.body, usage };
 }
 
 /**
@@ -241,8 +282,8 @@ const TrackContentSchema = z.object({
 });
 
 /**
- * Third system-prompt variant alongside SYSTEM_PROMPT_WITH_NOTE and
- * SYSTEM_PROMPT_NO_NOTE. Used for closed Garmin tracking sessions.
+ * Third system-prompt variant alongside SYSTEM_PROMPT_POST_WITH_NOTE and
+ * SYSTEM_PROMPT_POST_NO_NOTE. Used for closed Garmin tracking sessions.
  * Body cap is 3000 chars (vs 500 for !post). Explicitly forbids inventing
  * specifics not present in metrics or place names.
  */
@@ -264,63 +305,18 @@ const SYSTEM_PROMPT_TRACK = [
 export async function generateTrackNarrative(
   input: TrackNarrativeInput,
 ): Promise<NarrativeOutput> {
-  const userPrompt = buildTrackPrompt(input);
-  const model = input.env.LLM_MODEL || "anthropic/claude-sonnet-4-6";
-
-  const response = await chatCompletion({
-    req: {
-      model,
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT_TRACK },
-        { role: "user", content: userPrompt },
-      ],
-      response_format: { type: "json_schema", json_schema: TRACK_NARRATIVE_SCHEMA },
-      temperature: 0.7,
-      max_tokens: 1500,
-    },
+  const { data, usage } = await runNarrativeCall({
     env: input.env,
+    model: input.env.LLM_MODEL || "anthropic/claude-sonnet-4-6",
+    systemPrompt: SYSTEM_PROMPT_TRACK,
+    userPrompt: buildTrackPrompt(input),
+    responseSchema: TRACK_NARRATIVE_SCHEMA,
+    zodSchema: TrackContentSchema,
+    maxTokens: 1500,
+    diagKind: "track",
   });
 
-  const content = response.choices[0]?.message?.content;
-  if (typeof content !== "string" || content.length === 0) {
-    const choice0 = response.choices[0];
-    log({
-      event: "narrative_diag",
-      level: "warn",
-      diag: {
-        kind: "track",
-        model,
-        choicesLen: response.choices.length,
-        finishReason: choice0?.finish_reason ?? null,
-        messageKeys: choice0?.message ? Object.keys(choice0.message) : [],
-        contentType: typeof choice0?.message?.content,
-        contentLen:
-          typeof choice0?.message?.content === "string" ? choice0.message.content.length : 0,
-        usage: response.usage ?? null,
-      },
-    });
-    throw new NarrativeError("LLM returned no content for track narrative");
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch (e) {
-    throw new NarrativeError(`LLM returned non-JSON: ${content.slice(0, 120)}`, { cause: e });
-  }
-  const validated = TrackContentSchema.safeParse(parsed);
-  if (!validated.success) {
-    const issues = validated.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
-    throw new NarrativeError(`Track narrative failed schema: ${issues}`);
-  }
-  return {
-    title: validated.data.title,
-    haiku: validated.data.haiku,
-    body: validated.data.body,
-    usage: {
-      prompt_tokens: response.usage.prompt_tokens,
-      completion_tokens: response.usage.completion_tokens,
-    },
-  };
+  return { title: data.title, haiku: data.haiku, body: data.body, usage };
 }
 
 function buildTrackPrompt(input: TrackNarrativeInput): string {


### PR DESCRIPTION
## Summary

Three Cut-3 reviews flagged duplication between the `!post` variant and the new tracking variant of two pipelines (#168 Tasks 3.3/3.4/3.5). Extracts shared helpers so each variant is now a thin wrapper.

### Narrative (`src/core/narrative.ts`)

- **New `runNarrativeCall<T>`** owns the LLM call + response handling + diagnostics + zod validation + usage extraction. Variant differences (prompts, schemas, max_tokens, `diagKind`) come in as opts.
- `generateNarrative` and `generateTrackNarrative` collapsed to ~15 lines each.
- The `narrative_diag` log block is consolidated; `kind` discriminator preserved as a closed `"post" | "track"` literal.

### Publish (`src/adapters/publish/github-pages.ts`)

- **New `resolvePublishPath`** derives the dated path + slug + URL. Shared across **all three** publish callers (`publishPost`, `publishTrackPost`, `publishPostWithImage`).
- **New `publishMarkdown`** wraps `resolvePublishPath` + `renderFn` callback + Contents-API PUT retry. Shared by `publishPost` and `publishTrackPost`.
- `publishPostWithImage` calls `resolvePublishPath` directly and keeps its GraphQL `createCommitOnBranch` commit mechanism unchanged. The two-helper split keeps the path-resolution win without forcing the different commit mechanism into a shared abstraction.

### Parallel-naming renames

One file, no external imports:

| Before | After |
| --- | --- |
| `SYSTEM_PROMPT_WITH_NOTE` | `SYSTEM_PROMPT_POST_WITH_NOTE` |
| `SYSTEM_PROMPT_NO_NOTE` | `SYSTEM_PROMPT_POST_NO_NOTE` |
| `NARRATIVE_SCHEMA` | `POST_NARRATIVE_SCHEMA` |
| `NarrativeContentSchema` | `PostContentSchema` |

`SYSTEM_PROMPT_TRACK` / `TRACK_NARRATIVE_SCHEMA` / `TrackContentSchema` already followed the parallel naming.

Public API (`NarrativeOutput`, `NarrativeInput`, `NarrativeError`, `generateNarrative`, `generateTrackNarrative`, `publishPost`, `publishTrackPost`, `publishPostWithImage`) is unchanged — no test imports affected.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` green (408 tests, 36 files)
- [x] No behavior change; tests touch zero (refactor-only)
- [x] `vi.spyOn(narrativeMod, "generateTrackNarrative")` and `vi.spyOn(publishMod, "publishTrackPost")` still hook properly — confirmed by tracking.test.ts (14 tests) staying green
- [ ] PR CI green
- [ ] Merge → closes #174

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)